### PR TITLE
Add ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended",
+    "plugin:astro/recommended"
+  ],
+  "plugins": [
+    "react",
+    "react-hooks",
+    "jsx-a11y",
+    "astro"
+  ],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check:translations": "node scripts/check-translations.js",
     "a11y": "npm run check:contrast",
     "a11y:audit": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view --chrome-flags=\"--headless\" --only-categories=accessibility",
-    "clean": "rimraf dist .astro public/styles/font-awesome* public/styles/fonts"
+    "clean": "rimraf dist .astro public/styles/font-awesome* public/styles/fonts",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.astro"
   },
   "dependencies": {
     "@astrojs/react": "^3.0.9",


### PR DESCRIPTION
## Summary
- add a base `.eslintrc.json` with React and Astro plugins
- add `lint` script to package.json

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*