### PR TITLE
Add MIT and CC BY-NC licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Oriol Macias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE_CONTENT
+++ b/LICENSE_CONTENT
@@ -1,0 +1,5 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+This work (text and images in this repository) is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License. You may view a copy of the license at <https://creativecommons.org/licenses/by-nc/4.0/>.
+
+By using the text and images in this repository you agree to the terms of the license, including the requirement to provide attribution and the prohibition on commercial use without permission.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ npm run preview
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+The source code is licensed under the [MIT License](LICENSE).
+All text and images are provided under the [CC BY-NC 4.0](LICENSE_CONTENT) license.
 
 ## 📧 Contact
 


### PR DESCRIPTION
## Summary
- update year in MIT license
- note that text and images are CC BY-NC 4.0
- include a content license file

## Testing
- `npm run check` *(fails: Cannot find package 'wcag-contrast')*
