### PR TITLE
Fix netlify content-type header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,6 @@
 # Políticas de caché mejoradas para móvil
 /images/oriol_macias-sm.*
   Cache-Control: public, max-age=31536000, immutable
-  Content-Type: {{content-type}}
 
 /styles/fonts/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- remove unsupported Netlify `{{content-type}}` placeholder in `_headers`

## Testing
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*
- `npm run check` *(fails: Cannot find package 'wcag-contrast')*