### PR TITLE
Adjust script caching headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,13 +26,13 @@
   for = "/scripts/i18n.js"
   [headers.values]
     Content-Type = "application/javascript; charset=utf-8"
-    Cache-Control = "no-cache, no-store, must-revalidate"
+    Cache-Control = "public, max-age=31536000"
 
 [[headers]]
   for = "/scripts/font-awesome-loader.js"
   [headers.values]
     Content-Type = "application/javascript; charset=utf-8"
-    Cache-Control = "no-cache, no-store, must-revalidate"
+    Cache-Control = "public, max-age=31536000"
 
 # ===== SOLUCIÓN PARA FONT AWESOME =====
 


### PR DESCRIPTION
## Summary
- update cache policy for `i18n.js` and `font-awesome-loader.js` to long-lived TTL

## Testing
- `npx prettier --check netlify.toml --ignore-unknown`
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*