### PR TITLE
Fix Cloudflare redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -97,11 +97,6 @@
 
 # Ignorar recursos Cloudflare ausentes
 [[redirects]]
-  from = "/cdn-cgi/*"
-  to = "/.netlify/functions/empty-response"
-  status = 204
-
-[[redirects]]
   from = "/cdn-cgi/speculation"
   to = "/cdn-cgi/empty-response.js"
   status = 200
@@ -110,6 +105,11 @@
   from = "/cdn-cgi/rum"
   to = "/cdn-cgi/empty-response.js"
   status = 200
+
+[[redirects]]
+  from = "/cdn-cgi/*"
+  to = "/.netlify/functions/empty-response"
+  status = 204
 
 # Manejo de páginas no encontradas
 [[redirects]]


### PR DESCRIPTION
## Summary
- ensure `/cdn-cgi/speculation` and `/cdn-cgi/rum` redirect to a valid empty file
- put these rules before the wildcard `/cdn-cgi/*` rule

## Testing
- `npx prettier --write netlify.toml` *(fails: No parser could be inferred)*
- `npx prettier --check netlify.toml`
- `npm run lint netlify.toml` *(fails: Cannot find module '@humanwhocodes/config-array')*