### PR TITLE
Fix hydration mismatch for CV sections

### DIFF
--- a/src/components/cv/Education.jsx
+++ b/src/components/cv/Education.jsx
@@ -2,133 +2,148 @@
  * Education component with animations similar to Experience
  * File: src/components/cv/Education.jsx
  */
-import React, { useEffect, useState } from 'react';
-import { getCurrentLanguageEducation } from '../../data/education';
+import React, { useEffect, useState } from "react";
+import { getCurrentLanguageEducation } from "../../data/education";
 
 const Education = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [animatedItems, setAnimatedItems] = useState([]);
-    const [educationItems, setEducationItems] = useState([]);
-    const [translations, setTranslations] = useState({
-        title: 'Education & Certifications',
-        institution: 'Institution',
-        period: 'Period',
-        details: 'Details'
+  const [isVisible, setIsVisible] = useState(false);
+  const [animatedItems, setAnimatedItems] = useState([]);
+  const [educationItems, setEducationItems] = useState(() =>
+    getCurrentLanguageEducation(),
+  );
+  const [translations, setTranslations] = useState(() => ({
+    title: getTranslation("education.title", "Education & Certifications"),
+    institution: getTranslation("education.institution", "Institution"),
+    period: getTranslation("education.period", "Period"),
+    details: getTranslation("education.details", "Details"),
+  }));
+
+  // Function to safely get translations
+  const getTranslation = (key, defaultValue) => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      const translated = window.t(key);
+      if (translated) return translated;
+    }
+    return defaultValue;
+  };
+
+  // Load translations
+  const loadTranslations = () => {
+    setTranslations({
+      title: getTranslation("education.title", "Education & Certifications"),
+      institution: getTranslation("education.institution", "Institution"),
+      period: getTranslation("education.period", "Period"),
+      details: getTranslation("education.details", "Details"),
     });
 
-    // Function to safely get translations
-    const getTranslation = (key, defaultValue) => {
-        if (typeof window !== 'undefined' && typeof window.t === 'function') {
-            return window.t(key) || defaultValue;
+    // Also load education items in current language
+    const items = getCurrentLanguageEducation();
+    setEducationItems(items);
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+
+          // Load education items in current language
+          const items = getCurrentLanguageEducation();
+          setEducationItems(items);
+
+          // Start staggered animation sequence for education items
+          items.forEach((_, index) => {
+            setTimeout(
+              () => {
+                setAnimatedItems((prev) => [...prev, index]);
+              },
+              500 + index * 200,
+            ); // Slower animation similar to Experience
+          });
+
+          observer.disconnect();
         }
-        return defaultValue;
+      },
+      { threshold: 0.1 },
+    );
+
+    const element = document.getElementById("education");
+    if (element) {
+      observer.observe(element);
+    }
+
+    // Initial load of translations and data
+    loadTranslations();
+
+    // Listen for language changes
+    const handleLanguageChanged = () => {
+      loadTranslations();
     };
 
-    // Load translations
-    const loadTranslations = () => {
-        setTranslations({
-            title: getTranslation('education.title', 'Education & Certifications'),
-            institution: getTranslation('education.institution', 'Institution'),
-            period: getTranslation('education.period', 'Period'),
-            details: getTranslation('education.details', 'Details')
-        });
+    document.addEventListener("languageChanged", handleLanguageChanged);
+    document.addEventListener("translationsLoaded", handleLanguageChanged);
 
-        // Also load education items in current language
-        const items = getCurrentLanguageEducation();
-        setEducationItems(items);
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChanged);
+      document.removeEventListener("translationsLoaded", handleLanguageChanged);
     };
+  }, []);
 
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
+  return (
+    <section id="education">
+      <div
+        className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}`}
+      >
+        <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
+          <i className="fas fa-graduation-cap"></i>
+        </div>
+        <h2 className="text-2xl font-bold ml-3" data-i18n="education.title">
+          {translations.title}
+        </h2>
+      </div>
 
-                    // Load education items in current language
-                    const items = getCurrentLanguageEducation();
-                    setEducationItems(items);
+      <div className="space-y-6">
+        {educationItems.map((item, index) => {
+          const isItemAnimated = animatedItems.includes(index);
 
-                    // Start staggered animation sequence for education items
-                    items.forEach((_, index) => {
-                        setTimeout(() => {
-                            setAnimatedItems(prev => [...prev, index]);
-                        }, 500 + (index * 200)); // Slower animation similar to Experience
-                    });
-
-                    observer.disconnect();
-                }
-            },
-            { threshold: 0.1 }
-        );
-
-        const element = document.getElementById('education');
-        if (element) {
-            observer.observe(element);
-        }
-
-        // Initial load of translations and data
-        loadTranslations();
-
-        // Listen for language changes
-        const handleLanguageChanged = () => {
-            loadTranslations();
-        };
-
-        document.addEventListener('languageChanged', handleLanguageChanged);
-        document.addEventListener('translationsLoaded', handleLanguageChanged);
-
-        return () => {
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChanged);
-            document.removeEventListener('translationsLoaded', handleLanguageChanged);
-        };
-    }, []);
-
-    return (
-        <section id="education">
+          return (
             <div
-                className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'}`}
-            >
-                <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
-                    <i className="fas fa-graduation-cap"></i>
-                </div>
-                <h2 className="text-2xl font-bold ml-3" data-i18n="education.title">{translations.title}</h2>
-            </div>
-
-            <div className="space-y-6">
-                {educationItems.map((item, index) => {
-                    const isItemAnimated = animatedItems.includes(index);
-
-                    return (
-                        <div
-                            key={index}
-                            className={`group bg-light-surface dark:bg-dark-surface p-5 border-l-4 border-brand-red 
+              key={index}
+              className={`group bg-light-surface dark:bg-dark-surface p-5 border-l-4 border-brand-red 
                                      border-t border-r border-b border-t-light-border border-r-light-border border-b-light-border 
                                      dark:border-t-dark-border dark:border-r-dark-border dark:border-b-dark-border 
                                      rounded-none shadow-sm hover:shadow-md transition-all duration-700 transform 
-                                     ${isItemAnimated ? 'translate-x-0 opacity-100' : 'translate-x-[-20px] opacity-0'} 
+                                     ${isItemAnimated ? "translate-x-0 opacity-100" : "translate-x-[-20px] opacity-0"} 
                                      hover:translate-x-1 hover:border-l-8`}
-                        >
-                            <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-2 mb-2">
-                                <div>
-                                    <h3 className="font-bold text-lg group-hover:text-brand-red transition-colors duration-300">{item.title}</h3>
-                                    <p className="text-light-text-secondary dark:text-dark-text-secondary italic mb-2">{item.institution}</p>
-                                </div>
-                                <div className="inline-flex items-center px-3 py-1 text-xs text-light-text-secondary dark:text-dark-text-secondary bg-light-secondary dark:bg-dark-secondary rounded-none group-hover:bg-brand-red group-hover:text-white transition-colors duration-300">
-                                    <i className="fas fa-calendar-alt mr-2" aria-hidden="true"></i>
-                                    {item.period}
-                                </div>
-                            </div>
-                            <p className="text-sm">{item.details}</p>
+            >
+              <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-2 mb-2">
+                <div>
+                  <h3 className="font-bold text-lg group-hover:text-brand-red transition-colors duration-300">
+                    {item.title}
+                  </h3>
+                  <p className="text-light-text-secondary dark:text-dark-text-secondary italic mb-2">
+                    {item.institution}
+                  </p>
+                </div>
+                <div className="inline-flex items-center px-3 py-1 text-xs text-light-text-secondary dark:text-dark-text-secondary bg-light-secondary dark:bg-dark-secondary rounded-none group-hover:bg-brand-red group-hover:text-white transition-colors duration-300">
+                  <i
+                    className="fas fa-calendar-alt mr-2"
+                    aria-hidden="true"
+                  ></i>
+                  {item.period}
+                </div>
+              </div>
+              <p className="text-sm">{item.details}</p>
 
-                            {/* Indicator line with smoother animation */}
-                            <div className="w-0 h-0.5 bg-brand-red mt-3 transition-all duration-300 group-hover:w-full"></div>
-                        </div>
-                    );
-                })}
+              {/* Indicator line with smoother animation */}
+              <div className="w-0 h-0.5 bg-brand-red mt-3 transition-all duration-300 group-hover:w-full"></div>
             </div>
-        </section>
-    );
+          );
+        })}
+      </div>
+    </section>
+  );
 };
 
 export default Education;

--- a/src/components/cv/Experience.jsx
+++ b/src/components/cv/Experience.jsx
@@ -2,204 +2,252 @@
  * Experience component with internationalization support
  * File: src/components/cv/Experience.jsx
  */
-import React, { useEffect, useState, useCallback } from 'react';
-import { getCurrentLanguageExperiences } from '../../data/experiences';
+import React, { useEffect, useState, useCallback } from "react";
+import { getCurrentLanguageExperiences } from "../../data/experiences";
 
 /**
  * Experience component displays work history in a timeline format
  * Uses multilingual data and supports language switching
  */
 const Experience = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [expandedJobs, setExpandedJobs] = useState({});
-    const [experiences, setExperiences] = useState([]);
-    const [translations, setTranslations] = useState({
-        title: 'Work Experience',
-        responsibilities: 'Responsibilities',
-        keyAchievements: 'Key Achievements',
-        showMore: 'Show more',
-        showLess: 'Show less'
-    });
+  const [isVisible, setIsVisible] = useState(false);
+  const [expandedJobs, setExpandedJobs] = useState({});
+  const [experiences, setExperiences] = useState(() =>
+    getCurrentLanguageExperiences(),
+  );
 
-    // Load translations and experiences data safely
-    const loadTranslations = useCallback(() => {
-        // Get current language experiences data
-        setExperiences(getCurrentLanguageExperiences());
+  const getTranslation = (key, defaultValue) => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      const translated = window.t(key);
+      if (translated) return translated;
+    }
+    return defaultValue;
+  };
 
-        // Get UI translations safely
-        if (typeof window !== 'undefined' && typeof window.t === 'function') {
-            setTranslations({
-                title: window.t('experience.title') || 'Work Experience',
-                responsibilities: window.t('experience.responsibilities') || 'Responsibilities',
-                keyAchievements: window.t('experience.keyAchievements') || 'Key Achievements',
-                showMore: window.t('experience.showMore') || 'Show more',
-                showLess: window.t('experience.showLess') || 'Show less'
-            });
+  const [translations, setTranslations] = useState(() => ({
+    title: getTranslation("experience.title", "Work Experience"),
+    responsibilities: getTranslation(
+      "experience.responsibilities",
+      "Responsibilities",
+    ),
+    keyAchievements: getTranslation(
+      "experience.keyAchievements",
+      "Key Achievements",
+    ),
+    showMore: getTranslation("experience.showMore", "Show more"),
+    showLess: getTranslation("experience.showLess", "Show less"),
+  }));
+
+  // Load translations and experiences data safely
+  const loadTranslations = useCallback(() => {
+    // Get current language experiences data
+    setExperiences(getCurrentLanguageExperiences());
+
+    // Get UI translations safely
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      setTranslations({
+        title: window.t("experience.title") || "Work Experience",
+        responsibilities:
+          window.t("experience.responsibilities") || "Responsibilities",
+        keyAchievements:
+          window.t("experience.keyAchievements") || "Key Achievements",
+        showMore: window.t("experience.showMore") || "Show more",
+        showLess: window.t("experience.showLess") || "Show less",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Set up intersection observer for animation
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
         }
-    }, []);
+      },
+      { threshold: 0.1 },
+    );
 
-    useEffect(() => {
-        // Set up intersection observer for animation
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
-                    observer.disconnect();
-                }
-            },
-            { threshold: 0.1 }
-        );
+    const element = document.getElementById("experience");
+    if (element) {
+      observer.observe(element);
+    }
 
-        const element = document.getElementById('experience');
-        if (element) {
-            observer.observe(element);
-        }
+    // Load initial translations and data
+    loadTranslations();
 
-        // Load initial translations and data
-        loadTranslations();
-
-        // Listen for language changes
-        const handleLanguageChange = () => {
-            loadTranslations();
-        };
-
-        document.addEventListener('languageChanged', handleLanguageChange);
-
-        return () => {
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChange);
-        };
-    }, [loadTranslations]);
-
-    /**
-     * Toggle expand/collapse for a specific job
-     * @param {string} jobId - ID of the job to toggle
-     */
-    const toggleJobDetails = (jobId) => {
-        setExpandedJobs(prev => ({
-            ...prev,
-            [jobId]: !prev[jobId]
-        }));
+    // Listen for language changes
+    const handleLanguageChange = () => {
+      loadTranslations();
     };
 
-    return (
-        <section id="experience" className="scroll-mt-20 mb-16">
+    document.addEventListener("languageChanged", handleLanguageChange);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChange);
+    };
+  }, [loadTranslations]);
+
+  /**
+   * Toggle expand/collapse for a specific job
+   * @param {string} jobId - ID of the job to toggle
+   */
+  const toggleJobDetails = (jobId) => {
+    setExpandedJobs((prev) => ({
+      ...prev,
+      [jobId]: !prev[jobId],
+    }));
+  };
+
+  return (
+    <section id="experience" className="scroll-mt-20 mb-16">
+      <div
+        className={`flex items-center gap-4 mb-10 transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}`}
+      >
+        <div className="h-10 w-10 bg-brand-red dark:bg-brand-red rounded-none flex items-center justify-center flex-shrink-0 transition-colors duration-150">
+          <i className="fas fa-briefcase text-white"></i>
+        </div>
+        <h2
+          className="text-3xl font-bold tracking-tight"
+          data-i18n="experience.title"
+        >
+          {translations.title}
+        </h2>
+      </div>
+
+      <div className="relative pl-5 md:pl-8">
+        {/* Timeline line with gradient */}
+        <div className="absolute left-2 top-4 bottom-0 w-0.5 bg-gradient-to-b from-brand-red via-brand-red/70 to-gray-300 dark:from-brand-red dark:via-brand-red/50 dark:to-gray-700"></div>
+
+        {experiences.map((job, index) => (
+          <div
+            key={job.id}
+            className={`relative pl-8 pb-12 transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"} hover:translate-x-1`}
+            style={{ transitionDelay: `${200 * index}ms` }}
+          >
+            {/* Timeline node */}
             <div
-                className={`flex items-center gap-4 mb-10 transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'}`}
-            >
-                <div className="h-10 w-10 bg-brand-red dark:bg-brand-red rounded-none flex items-center justify-center flex-shrink-0 transition-colors duration-150">
-                    <i className="fas fa-briefcase text-white"></i>
-                </div>
-                <h2 className="text-3xl font-bold tracking-tight" data-i18n="experience.title">{translations.title}</h2>
-            </div>
+              className={`absolute left-0 top-4 w-4 h-4 rounded-none bg-brand-red dark:bg-brand-red border-4 border-white dark:border-gray-900 shadow-sm transition-all duration-500 ${isVisible ? "opacity-100 scale-100" : "opacity-0 scale-0"}`}
+              style={{
+                opacity: isVisible ? 1 - index * 0.15 : 0,
+                transitionDelay: `${300 * index}ms`,
+              }}
+            ></div>
 
-            <div className="relative pl-5 md:pl-8">
-                {/* Timeline line with gradient */}
-                <div className="absolute left-2 top-4 bottom-0 w-0.5 bg-gradient-to-b from-brand-red via-brand-red/70 to-gray-300 dark:from-brand-red dark:via-brand-red/50 dark:to-gray-700"></div>
-
-                {experiences.map((job, index) => (
-                    <div
-                        key={job.id}
-                        className={`relative pl-8 pb-12 transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'} hover:translate-x-1`}
-                        style={{ transitionDelay: `${200 * index}ms` }}
+            {/* Job header with hover effects */}
+            <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 mb-4 group">
+              <div>
+                <h3 className="text-xl font-bold group-hover:text-brand-red transition-colors duration-150">
+                  {job.title}
+                </h3>
+                <p className="text-light-text-secondary dark:text-dark-text-secondary transition-colors duration-150 flex items-center">
+                  <i className="fas fa-building mr-2 text-brand-red/70"></i>
+                  {job.companyUrl ? (
+                    <a
+                      href={job.companyUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-brand-red dark:hover:text-brand-red transition-colors"
+                      aria-label={`Visit ${job.company} website`}
                     >
-                        {/* Timeline node */}
-                        <div
-                            className={`absolute left-0 top-4 w-4 h-4 rounded-none bg-brand-red dark:bg-brand-red border-4 border-white dark:border-gray-900 shadow-sm transition-all duration-500 ${isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-0'}`}
-                            style={{
-                                opacity: isVisible ? (1 - (index * 0.15)) : 0,
-                                transitionDelay: `${300 * index}ms`
-                            }}
-                        ></div>
-
-                        {/* Job header with hover effects */}
-                        <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 mb-4 group">
-                            <div>
-                                <h3 className="text-xl font-bold group-hover:text-brand-red transition-colors duration-150">{job.title}</h3>
-                                <p className="text-light-text-secondary dark:text-dark-text-secondary transition-colors duration-150 flex items-center">
-                                    <i className="fas fa-building mr-2 text-brand-red/70"></i>
-                                    {job.companyUrl ? (
-
-                                        <a href={job.companyUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="hover:text-brand-red dark:hover:text-brand-red transition-colors"
-                                            aria-label={`Visit ${job.company} website`}
-                                        >
-                                            {job.company}
-                                        </a>
-                                    ) : (
-                                        job.company
-                                    )}
-                                </p>
-                            </div>
-                            <div className="flex items-center gap-2 text-sm text-light-text-secondary dark:text-dark-text-secondary bg-light-secondary dark:bg-dark-secondary px-3 py-1 rounded-none transition-all duration-150 group-hover:bg-brand-red group-hover:text-white">
-                                <i className="fas fa-calendar-alt"></i>
-                                <span>{job.period}</span>
-                            </div>
-                        </div>
-
-                        {/* Job description with enhanced hover effects */}
-                        <div className="bg-light-surface dark:bg-dark-surface p-6 rounded-none border border-light-border dark:border-dark-border group hover:border-brand-red/30 dark:hover:border-brand-red/30 transition-all duration-150 hover:shadow-md">
-                            {/* Responsibilities section - condensed */}
-                            <h4 className="text-sm uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-3 tracking-wider" data-i18n="experience.responsibilities">
-                                {translations.responsibilities}
-                            </h4>
-                            <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150 mb-3">
-                                {job.keyResponsibilities && job.keyResponsibilities.map((responsibility, i) => (
-                                    <li key={i} className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150">
-                                        <span className="w-1.5 h-1.5 bg-brand-red flex-shrink-0 mt-2 transition-all duration-150 group-hover/item:scale-125"></span>
-                                        <span>{responsibility}</span>
-                                    </li>
-                                ))}
-                            </ul>
-
-                            {/* Extra responsibilities - expandable */}
-                            {job.extraResponsibilities && job.extraResponsibilities.length > 0 && (
-                                <>
-                                    {expandedJobs[job.id] && (
-                                        <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150 mb-3 animate-fade-in">
-                                            {job.extraResponsibilities.map((responsibility, i) => (
-                                                <li key={`extra-${i}`} className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150">
-                                                    <span className="w-1.5 h-1.5 bg-brand-red flex-shrink-0 mt-2 transition-all duration-150 group-hover/item:scale-125"></span>
-                                                    <span>{responsibility}</span>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    )}
-
-                                    <button
-                                        onClick={() => toggleJobDetails(job.id)}
-                                        className="text-xs inline-flex items-center gap-1 text-brand-red hover:text-brand-red/80 mb-5 focus:outline-none focus:underline"
-                                        aria-expanded={!!expandedJobs[job.id]}
-                                    >
-                                        <i className={`fas fa-chevron-${expandedJobs[job.id] ? 'up' : 'down'} text-xs`}></i>
-                                        {expandedJobs[job.id] ? translations.showLess : translations.showMore}
-                                    </button>
-                                </>
-                            )}
-
-                            {/* Achievements section with trophy icons */}
-                            <h4 className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-3 tracking-wider" data-i18n="experience.keyAchievements">
-                                {translations.keyAchievements}
-                            </h4>
-                            <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150">
-                                {job.achievements && job.achievements.map((achievement, i) => (
-                                    <li key={i} className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150">
-                                        <i className="fas fa-trophy text-brand-red flex-shrink-0 mt-1 transition-all duration-150 group-hover/item:scale-125"></i>
-                                        <span>{achievement}</span>
-                                    </li>
-                                ))}
-                            </ul>
-
-                            {/* Hover indicator animation */}
-                            <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full"></div>
-                        </div>
-                    </div>
-                ))}
+                      {job.company}
+                    </a>
+                  ) : (
+                    job.company
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-light-text-secondary dark:text-dark-text-secondary bg-light-secondary dark:bg-dark-secondary px-3 py-1 rounded-none transition-all duration-150 group-hover:bg-brand-red group-hover:text-white">
+                <i className="fas fa-calendar-alt"></i>
+                <span>{job.period}</span>
+              </div>
             </div>
-        </section>
-    );
+
+            {/* Job description with enhanced hover effects */}
+            <div className="bg-light-surface dark:bg-dark-surface p-6 rounded-none border border-light-border dark:border-dark-border group hover:border-brand-red/30 dark:hover:border-brand-red/30 transition-all duration-150 hover:shadow-md">
+              {/* Responsibilities section - condensed */}
+              <h4
+                className="text-sm uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-3 tracking-wider"
+                data-i18n="experience.responsibilities"
+              >
+                {translations.responsibilities}
+              </h4>
+              <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150 mb-3">
+                {job.keyResponsibilities &&
+                  job.keyResponsibilities.map((responsibility, i) => (
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150"
+                    >
+                      <span className="w-1.5 h-1.5 bg-brand-red flex-shrink-0 mt-2 transition-all duration-150 group-hover/item:scale-125"></span>
+                      <span>{responsibility}</span>
+                    </li>
+                  ))}
+              </ul>
+
+              {/* Extra responsibilities - expandable */}
+              {job.extraResponsibilities &&
+                job.extraResponsibilities.length > 0 && (
+                  <>
+                    {expandedJobs[job.id] && (
+                      <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150 mb-3 animate-fade-in">
+                        {job.extraResponsibilities.map((responsibility, i) => (
+                          <li
+                            key={`extra-${i}`}
+                            className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150"
+                          >
+                            <span className="w-1.5 h-1.5 bg-brand-red flex-shrink-0 mt-2 transition-all duration-150 group-hover/item:scale-125"></span>
+                            <span>{responsibility}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    <button
+                      onClick={() => toggleJobDetails(job.id)}
+                      className="text-xs inline-flex items-center gap-1 text-brand-red hover:text-brand-red/80 mb-5 focus:outline-none focus:underline"
+                      aria-expanded={!!expandedJobs[job.id]}
+                    >
+                      <i
+                        className={`fas fa-chevron-${expandedJobs[job.id] ? "up" : "down"} text-xs`}
+                      ></i>
+                      {expandedJobs[job.id]
+                        ? translations.showLess
+                        : translations.showMore}
+                    </button>
+                  </>
+                )}
+
+              {/* Achievements section with trophy icons */}
+              <h4
+                className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-3 tracking-wider"
+                data-i18n="experience.keyAchievements"
+              >
+                {translations.keyAchievements}
+              </h4>
+              <ul className="space-y-3 text-light-text dark:text-dark-text transition-colors duration-150">
+                {job.achievements &&
+                  job.achievements.map((achievement, i) => (
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 group/item hover:translate-x-1 transition-all duration-150"
+                    >
+                      <i className="fas fa-trophy text-brand-red flex-shrink-0 mt-1 transition-all duration-150 group-hover/item:scale-125"></i>
+                      <span>{achievement}</span>
+                    </li>
+                  ))}
+              </ul>
+
+              {/* Hover indicator animation */}
+              <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full"></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 };
 
 export default Experience;

--- a/src/components/cv/Languages.jsx
+++ b/src/components/cv/Languages.jsx
@@ -2,133 +2,158 @@
  * Languages component with animations and multilingual support
  * File: src/components/cv/Languages.jsx
  */
-import React, { useEffect, useState } from 'react';
-import { getCurrentLanguageLanguages } from '../../data/languages';
+import React, { useEffect, useState } from "react";
+import { getCurrentLanguageLanguages } from "../../data/languages";
 
 const Languages = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [progressAnimation, setProgressAnimation] = useState({});
-    const [languagesData, setLanguagesData] = useState([]);
-    const [title, setTitle] = useState('Languages');
+  const [isVisible, setIsVisible] = useState(false);
+  const [progressAnimation, setProgressAnimation] = useState({});
+  const [languagesData, setLanguagesData] = useState(() =>
+    getCurrentLanguageLanguages(),
+  );
 
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
+  const getTranslation = (key, defaultValue) => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      const translated = window.t(key);
+      if (translated) return translated;
+    }
+    return defaultValue;
+  };
 
-                    // Get languages in current UI language
-                    const languages = getCurrentLanguageLanguages();
-                    setLanguagesData(languages);
+  const [title, setTitle] = useState(() =>
+    getTranslation("languages.title", "Languages"),
+  );
 
-                    // Start progress bar animations with natural staggering
-                    languages.forEach((lang, index) => {
-                        setTimeout(() => {
-                            setProgressAnimation(prev => ({
-                                ...prev,
-                                [lang.language]: true
-                            }));
-                        }, 500 + (index * 250)); // Slower, similar to Experience
-                    });
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
 
-                    observer.disconnect();
-                }
-            },
-            { threshold: 0.1 }
-        );
+          // Get languages in current UI language
+          const languages = getCurrentLanguageLanguages();
+          setLanguagesData(languages);
 
-        const element = document.getElementById('languages');
-        if (element) {
-            observer.observe(element);
+          // Start progress bar animations with natural staggering
+          languages.forEach((lang, index) => {
+            setTimeout(
+              () => {
+                setProgressAnimation((prev) => ({
+                  ...prev,
+                  [lang.language]: true,
+                }));
+              },
+              500 + index * 250,
+            ); // Slower, similar to Experience
+          });
+
+          observer.disconnect();
         }
-
-        // Initial load of languages data
-        setLanguagesData(getCurrentLanguageLanguages());
-
-        // Update title based on current language
-        if (typeof window !== 'undefined' && typeof window.t === 'function') {
-            setTitle(window.t('languages.title') || 'Languages');
-        }
-
-        // Listen for language changes
-        const handleLanguageChanged = () => {
-            const newLanguages = getCurrentLanguageLanguages();
-            setLanguagesData(newLanguages);
-
-            // Reset and restart progress animations
-            setProgressAnimation({});
-            newLanguages.forEach((lang, index) => {
-                setTimeout(() => {
-                    setProgressAnimation(prev => ({
-                        ...prev,
-                        [lang.language]: true
-                    }));
-                }, 300 + (index * 150));
-            });
-
-            // Update title
-            if (typeof window !== 'undefined' && typeof window.t === 'function') {
-                setTitle(window.t('languages.title') || 'Languages');
-            }
-        };
-
-        document.addEventListener('languageChanged', handleLanguageChanged);
-        document.addEventListener('translationsLoaded', handleLanguageChanged);
-
-        return () => {
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChanged);
-            document.removeEventListener('translationsLoaded', handleLanguageChanged);
-        };
-    }, []);
-
-    return (
-        <section id="languages" className="mb-16">
-            <div
-                className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'}`}
-            >
-                <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
-                    <i className="fas fa-language"></i>
-                </div>
-                <h2 className="text-2xl font-bold ml-3" data-i18n="languages.title">{title}</h2>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                {languagesData.map((lang, index) => (
-                    <div
-                        key={index}
-                        className={`group bg-light-surface dark:bg-dark-surface rounded-none p-4 border border-light-border dark:border-dark-border transition-all duration-700 transform hover:-translate-y-1 hover:shadow-md ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'}`}
-                        style={{ transitionDelay: `${300 * index}ms` }} // Slower, similar to Experience
-                    >
-                        <div className="flex justify-between items-center mb-4">
-                            <span className="font-medium text-lg">{lang.language}</span>
-                            <span className="px-2 py-0.5 rounded-none text-xs font-semibold bg-brand-red text-white">
-                                {lang.badge}
-                            </span>
-                        </div>
-
-                        <div className="mt-2 space-y-2">
-                            <div className="text-light-text-secondary dark:text-dark-text-secondary text-sm mb-1">
-                                {lang.level}
-                            </div>
-
-                            {/* Progress bar with slower animation */}
-                            <div className="h-1.5 bg-light-secondary dark:bg-dark-secondary rounded-none overflow-hidden">
-                                <div
-                                    className="h-full bg-brand-red"
-                                    style={{
-                                        width: progressAnimation[lang.language] ? `${lang.percent}%` : '0%',
-                                        transition: 'width 1200ms cubic-bezier(0.25, 1, 0.5, 1)', // Slower animation
-                                        transitionDelay: progressAnimation[lang.language] ? '100ms' : '0ms'
-                                    }}
-                                ></div>
-                            </div>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        </section>
+      },
+      { threshold: 0.1 },
     );
+
+    const element = document.getElementById("languages");
+    if (element) {
+      observer.observe(element);
+    }
+
+    // Initial load of languages data
+    setLanguagesData(getCurrentLanguageLanguages());
+
+    // Update title based on current language
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      setTitle(window.t("languages.title") || "Languages");
+    }
+
+    // Listen for language changes
+    const handleLanguageChanged = () => {
+      const newLanguages = getCurrentLanguageLanguages();
+      setLanguagesData(newLanguages);
+
+      // Reset and restart progress animations
+      setProgressAnimation({});
+      newLanguages.forEach((lang, index) => {
+        setTimeout(
+          () => {
+            setProgressAnimation((prev) => ({
+              ...prev,
+              [lang.language]: true,
+            }));
+          },
+          300 + index * 150,
+        );
+      });
+
+      // Update title
+      if (typeof window !== "undefined" && typeof window.t === "function") {
+        setTitle(window.t("languages.title") || "Languages");
+      }
+    };
+
+    document.addEventListener("languageChanged", handleLanguageChanged);
+    document.addEventListener("translationsLoaded", handleLanguageChanged);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChanged);
+      document.removeEventListener("translationsLoaded", handleLanguageChanged);
+    };
+  }, []);
+
+  return (
+    <section id="languages" className="mb-16">
+      <div
+        className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}`}
+      >
+        <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
+          <i className="fas fa-language"></i>
+        </div>
+        <h2 className="text-2xl font-bold ml-3" data-i18n="languages.title">
+          {title}
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {languagesData.map((lang, index) => (
+          <div
+            key={index}
+            className={`group bg-light-surface dark:bg-dark-surface rounded-none p-4 border border-light-border dark:border-dark-border transition-all duration-700 transform hover:-translate-y-1 hover:shadow-md ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}`}
+            style={{ transitionDelay: `${300 * index}ms` }} // Slower, similar to Experience
+          >
+            <div className="flex justify-between items-center mb-4">
+              <span className="font-medium text-lg">{lang.language}</span>
+              <span className="px-2 py-0.5 rounded-none text-xs font-semibold bg-brand-red text-white">
+                {lang.badge}
+              </span>
+            </div>
+
+            <div className="mt-2 space-y-2">
+              <div className="text-light-text-secondary dark:text-dark-text-secondary text-sm mb-1">
+                {lang.level}
+              </div>
+
+              {/* Progress bar with slower animation */}
+              <div className="h-1.5 bg-light-secondary dark:bg-dark-secondary rounded-none overflow-hidden">
+                <div
+                  className="h-full bg-brand-red"
+                  style={{
+                    width: progressAnimation[lang.language]
+                      ? `${lang.percent}%`
+                      : "0%",
+                    transition: "width 1200ms cubic-bezier(0.25, 1, 0.5, 1)", // Slower animation
+                    transitionDelay: progressAnimation[lang.language]
+                      ? "100ms"
+                      : "0ms",
+                  }}
+                ></div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 };
 
 export default Languages;

--- a/src/components/cv/ProfileHeader.jsx
+++ b/src/components/cv/ProfileHeader.jsx
@@ -2,256 +2,284 @@
  * Componente ProfileHeader con fix para ruta de imagen
  * File: src/components/cv/ProfileHeader.jsx
  */
-import React, { useState, useEffect } from 'react';
-import ResponsiveImage from '../ResponsiveImage';
-import headerData from '../../data/header';
+import React, { useState, useEffect } from "react";
+import ResponsiveImage from "../ResponsiveImage";
+import headerData from "../../data/header";
 
 const ProfileHeader = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [photoLoaded, setPhotoLoaded] = useState(false);
-    const [localData, setLocalData] = useState({
-        ...headerData,
-        jobTitle: headerData.jobTitle || "Software Developer",
-        summary: headerData.summary || "",
-        photoAlt: headerData.photoAlt || "Oriol Macias - Software Developer"
+  const getTranslation = (key, defaultValue) => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      const translated = window.t(key);
+      if (translated && translated !== key.split(".").pop()) {
+        return translated;
+      }
+    }
+
+    if (typeof window !== "undefined" && window.TRANSLATIONS) {
+      const currentLang = window.CURRENT_LANGUAGE || "en";
+      const translations = window.TRANSLATIONS[currentLang];
+
+      if (translations) {
+        const keys = key.split(".");
+        let result = translations;
+
+        for (const k of keys) {
+          if (result && typeof result === "object" && k in result) {
+            result = result[k];
+          } else {
+            result = null;
+            break;
+          }
+        }
+
+        if (result) return result;
+      }
+    }
+
+    if (key === "header.jobTitle") return headerData.jobTitle;
+    if (key === "header.summary") return headerData.summary;
+    if (key === "header.photoAlt") return headerData.photoAlt;
+
+    return defaultValue || key.split(".").pop();
+  };
+
+  const [isVisible, setIsVisible] = useState(false);
+  const [photoLoaded, setPhotoLoaded] = useState(false);
+  const [localData, setLocalData] = useState(() => ({
+    ...headerData,
+    jobTitle: getTranslation("header.jobTitle", headerData.jobTitle),
+    summary: getTranslation("header.summary", headerData.summary),
+    photoAlt: getTranslation("header.photoAlt", headerData.photoAlt),
+    email: getTranslation("header.email", "Email"),
+    linkedin: getTranslation("header.linkedin", "LinkedIn"),
+    github: getTranslation("header.github", "GitHub"),
+    downloadCV: getTranslation("buttons.downloadCV", "Download CV"),
+    downloadCoverLetter: getTranslation(
+      "buttons.downloadCoverLetter",
+      "Download Cover Letter",
+    ),
+  }));
+
+  // Cargar traducciones
+  const loadTranslations = () => {
+    setLocalData({
+      ...headerData,
+      jobTitle: getTranslation("header.jobTitle", headerData.jobTitle),
+      summary: getTranslation("header.summary", headerData.summary),
+      photoAlt: getTranslation("header.photoAlt", headerData.photoAlt),
+      email: getTranslation("header.email", "Email"),
+      linkedin: getTranslation("header.linkedin", "LinkedIn"),
+      github: getTranslation("header.github", "GitHub"),
+      downloadCV: getTranslation("buttons.downloadCV", "Download CV"),
+      downloadCoverLetter: getTranslation(
+        "buttons.downloadCoverLetter",
+        "Download Cover Letter",
+      ),
     });
+  };
 
-    // Función segura para obtener traducciones con fallbacks robustos
-    const getTranslation = (key, defaultValue) => {
-        // Verificar si la API de traducción está disponible
-        if (typeof window !== 'undefined' && typeof window.t === 'function') {
-            const translated = window.t(key);
+  useEffect(() => {
+    // Iniciar animación
+    const timer = setTimeout(() => {
+      setIsVisible(true);
+    }, 100);
 
-            // Comprobar si la traducción es válida (no es solo la clave)
-            if (translated && translated !== key.split('.').pop()) {
-                return translated;
-            }
+    // Cargar traducciones iniciales
+    loadTranslations();
+
+    // Observer para detección de visibilidad
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
         }
-
-        // Fallback 1: Buscar en TRANSLATIONS si está disponible
-        if (typeof window !== 'undefined' && window.TRANSLATIONS) {
-            const currentLang = window.CURRENT_LANGUAGE || 'en';
-            const translations = window.TRANSLATIONS[currentLang];
-
-            if (translations) {
-                const keys = key.split('.');
-                let result = translations;
-
-                for (const k of keys) {
-                    if (result && typeof result === 'object' && k in result) {
-                        result = result[k];
-                    } else {
-                        result = null;
-                        break;
-                    }
-                }
-
-                if (result) return result;
-            }
-        }
-
-        // Fallback 2: Devolver el valor de headerData si coincide con la clave
-        if (key === 'header.jobTitle') return headerData.jobTitle;
-        if (key === 'header.summary') return headerData.summary;
-        if (key === 'header.photoAlt') return headerData.photoAlt;
-
-        // Fallback 3: Usar el valor predeterminado proporcionado
-        return defaultValue || key.split('.').pop();
-    };
-
-    // Cargar traducciones
-    const loadTranslations = () => {
-        setLocalData({
-            ...headerData,
-            jobTitle: getTranslation('header.jobTitle', headerData.jobTitle),
-            summary: getTranslation('header.summary', headerData.summary),
-            photoAlt: getTranslation('header.photoAlt', headerData.photoAlt),
-            email: getTranslation('header.email', 'Email'),
-            linkedin: getTranslation('header.linkedin', 'LinkedIn'),
-            github: getTranslation('header.github', 'GitHub'),
-            downloadCV: getTranslation('buttons.downloadCV', 'Download CV'),
-            downloadCoverLetter: getTranslation('buttons.downloadCoverLetter', 'Download Cover Letter')
-        });
-    };
-
-    useEffect(() => {
-        // Iniciar animación
-        const timer = setTimeout(() => {
-            setIsVisible(true);
-        }, 100);
-
-        // Cargar traducciones iniciales
-        loadTranslations();
-
-        // Observer para detección de visibilidad
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
-                    observer.disconnect();
-                }
-            },
-            { threshold: 0.1 }
-        );
-
-        const element = document.getElementById('about');
-        if (element) {
-            observer.observe(element);
-        }
-
-        // Escuchar cambios de idioma
-        const handleLanguageChange = () => {
-            loadTranslations();
-        };
-
-        document.addEventListener('languageChanged', handleLanguageChange);
-        document.addEventListener('translationsLoaded', handleLanguageChange);
-
-        return () => {
-            clearTimeout(timer);
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChange);
-            document.removeEventListener('translationsLoaded', handleLanguageChange);
-        };
-    }, []);
-
-    // Función para manejar carga de imagen
-    const handleImageLoaded = () => {
-        setPhotoLoaded(true);
-    };
-
-    // Función para descargar el CV
-    const handleCVDownload = () => {
-        const pdfUrl = '/OriolMacias_CV.pdf';
-        const link = document.createElement('a');
-        link.href = pdfUrl;
-        link.download = 'OriolMacias_CV.pdf';
-        link.target = '_blank';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    };
-
-    // Función para descargar la carta de presentación
-    const handleCoverLetterDownload = () => {
-        const pdfUrl = '/OriolMacias_CoverLetter.pdf';
-        const link = document.createElement('a');
-        link.href = pdfUrl;
-        link.download = 'OriolMacias_CoverLetter.pdf';
-        link.target = '_blank';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    };
-
-    return (
-        <div id="about" className="pt-4 pb-8">
-            {/* Header / Información Personal */}
-            <section>
-                <div className={`grid grid-cols-1 md:grid-cols-12 gap-8 items-center transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
-                    {/* Información personal */}
-                    <div className="md:col-span-8 space-y-6">
-                        <div>
-                            <h1 className="text-4xl md:text-5xl font-bold mb-2">{headerData.fullName}</h1>
-                            <h2
-                                className="text-xl md:text-2xl text-brand-red dark:text-brand-red font-medium"
-                                data-i18n="header.jobTitle"
-                            >
-                                {localData.jobTitle}
-                            </h2>
-                        </div>
-
-                        <p
-                            className="text-gray-700 dark:text-gray-300 leading-relaxed text-lg max-w-2xl"
-                            data-i18n="header.summary"
-                        >
-                            {localData.summary}
-                        </p>
-
-                        {/* Información de contacto */}
-                        <div className="flex flex-wrap gap-4 mt-2">
-                            {headerData.contactInfo.map((contact, index) => (
-                                <div key={index} className="flex items-center gap-2 text-gray-700 dark:text-gray-300 group hover:translate-x-1 transition-all duration-300">
-                                    <a href={contact.type === 'email' ? `mailto:${contact.value}` : contact.url}
-                                        target={contact.type !== 'email' ? "_blank" : undefined}
-                                        rel={contact.type !== 'email' ? "noopener noreferrer" : undefined}
-                                        className="flex items-center gap-2 hover:text-brand-red dark:hover:text-brand-red transition-colors"
-                                        aria-label={localData[contact.type] || contact.label}
-                                    >
-                                        <div className="w-10 h-10 flex items-center justify-center text-white bg-brand-red/90 shadow-sm rounded-none mr-2 group-hover:bg-brand-red transition-all duration-300">
-                                            <i className={contact.icon}></i>
-                                        </div>
-                                        <div>
-                                            <span
-                                                className="text-xs block text-light-text-secondary dark:text-dark-text-secondary"
-                                                data-i18n={`header.${contact.type}`}
-                                            >
-                                                {localData[contact.type] || contact.label}
-                                            </span>
-                                            {contact.value}
-                                        </div>
-                                    </a>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Foto profesional con botones de descarga debajo */}
-                    <div className="md:col-span-4 flex flex-col justify-center md:justify-end">
-                        <div className={`relative w-100 h-100 md:w-100 md:h-100 overflow-hidden border-4 border-white dark:border-gray-800 shadow-lg transition-all duration-700 ${photoLoaded ? 'opacity-100' : 'opacity-80'}`}>
-                            {/* Borde para estructura */}
-                            <div className="absolute inset-0 border border-gray-200 dark:border-gray-700"></div>
-
-                            {/* Foto - ARREGLO: Usamos directamente la imagen de los formatos modernos */}
-                            <div className="w-full h-full bg-white dark:bg-gray-800">
-                                {/* Usar picture para formatos modernos y fallback a placeholder si fallan */}
-                                <picture>
-                                    {/* Formato AVIF - más eficiente */}
-                                    <source srcSet="/images/oriol_macias-sm.avif" type="image/avif" />
-                                    {/* Formato WebP - amplio soporte */}
-                                    <source srcSet="/images/oriol_macias-sm.webp" type="image/webp" />
-                                    {/* Fallback a placeholder */}
-                                    <img
-                                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400' viewBox='0 0 400 400'%3E%3Crect width='400' height='400' fill='%23f3f4f6'/%3E%3Ctext x='50%25' y='50%25' font-family='Arial' font-size='42' text-anchor='middle' fill='%239ca3af' dominant-baseline='middle'%3EOM%3C/text%3E%3C/svg%3E"
-                                        alt={localData.photoAlt}
-                                        width={400}
-                                        height={400}
-                                        loading="eager"
-                                        className="w-full h-full object-cover transition-opacity duration-500"
-                                        onLoad={handleImageLoaded}
-                                    />
-                                </picture>
-                            </div>
-
-                            {/* Acento rojo */}
-                            <div className="absolute bottom-0 left-0 right-0 h-2 bg-brand-red"></div>
-                        </div>
-
-                        {/* Botones de descarga con estilo consistente */}
-                        <div className="flex flex-col sm:flex-row gap-3 mt-4 justify-center">
-                            <button
-                                onClick={handleCVDownload}
-                                className="w-full sm:w-auto inline-flex items-center justify-center px-3 py-2 text-sm text-white bg-brand-red rounded-none hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-red focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-                                aria-label={localData.downloadCV}
-                            >
-                                <i className="fas fa-download mr-1.5"></i>
-                                <span>{localData.downloadCV}</span>
-                            </button>
-
-                            <button
-                                onClick={handleCoverLetterDownload}
-                                className="w-full sm:w-auto inline-flex items-center justify-center px-3 py-2 text-sm text-white bg-brand-red rounded-none hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-red focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-                                aria-label={localData.downloadCoverLetter}
-                            >
-                                <i className="fas fa-file-alt mr-1.5"></i>
-                                <span>{localData.downloadCoverLetter}</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </section>
-        </div>
+      },
+      { threshold: 0.1 },
     );
+
+    const element = document.getElementById("about");
+    if (element) {
+      observer.observe(element);
+    }
+
+    // Escuchar cambios de idioma
+    const handleLanguageChange = () => {
+      loadTranslations();
+    };
+
+    document.addEventListener("languageChanged", handleLanguageChange);
+    document.addEventListener("translationsLoaded", handleLanguageChange);
+
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChange);
+      document.removeEventListener("translationsLoaded", handleLanguageChange);
+    };
+  }, []);
+
+  // Función para manejar carga de imagen
+  const handleImageLoaded = () => {
+    setPhotoLoaded(true);
+  };
+
+  // Función para descargar el CV
+  const handleCVDownload = () => {
+    const pdfUrl = "/OriolMacias_CV.pdf";
+    const link = document.createElement("a");
+    link.href = pdfUrl;
+    link.download = "OriolMacias_CV.pdf";
+    link.target = "_blank";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  // Función para descargar la carta de presentación
+  const handleCoverLetterDownload = () => {
+    const pdfUrl = "/OriolMacias_CoverLetter.pdf";
+    const link = document.createElement("a");
+    link.href = pdfUrl;
+    link.download = "OriolMacias_CoverLetter.pdf";
+    link.target = "_blank";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div id="about" className="pt-4 pb-8">
+      {/* Header / Información Personal */}
+      <section>
+        <div
+          className={`grid grid-cols-1 md:grid-cols-12 gap-8 items-center transition-opacity duration-700 ${isVisible ? "opacity-100" : "opacity-0"}`}
+        >
+          {/* Información personal */}
+          <div className="md:col-span-8 space-y-6">
+            <div>
+              <h1 className="text-4xl md:text-5xl font-bold mb-2">
+                {headerData.fullName}
+              </h1>
+              <h2
+                className="text-xl md:text-2xl text-brand-red dark:text-brand-red font-medium"
+                data-i18n="header.jobTitle"
+              >
+                {localData.jobTitle}
+              </h2>
+            </div>
+
+            <p
+              className="text-gray-700 dark:text-gray-300 leading-relaxed text-lg max-w-2xl"
+              data-i18n="header.summary"
+            >
+              {localData.summary}
+            </p>
+
+            {/* Información de contacto */}
+            <div className="flex flex-wrap gap-4 mt-2">
+              {headerData.contactInfo.map((contact, index) => (
+                <div
+                  key={index}
+                  className="flex items-center gap-2 text-gray-700 dark:text-gray-300 group hover:translate-x-1 transition-all duration-300"
+                >
+                  <a
+                    href={
+                      contact.type === "email"
+                        ? `mailto:${contact.value}`
+                        : contact.url
+                    }
+                    target={contact.type !== "email" ? "_blank" : undefined}
+                    rel={
+                      contact.type !== "email"
+                        ? "noopener noreferrer"
+                        : undefined
+                    }
+                    className="flex items-center gap-2 hover:text-brand-red dark:hover:text-brand-red transition-colors"
+                    aria-label={localData[contact.type] || contact.label}
+                  >
+                    <div className="w-10 h-10 flex items-center justify-center text-white bg-brand-red/90 shadow-sm rounded-none mr-2 group-hover:bg-brand-red transition-all duration-300">
+                      <i className={contact.icon}></i>
+                    </div>
+                    <div>
+                      <span
+                        className="text-xs block text-light-text-secondary dark:text-dark-text-secondary"
+                        data-i18n={`header.${contact.type}`}
+                      >
+                        {localData[contact.type] || contact.label}
+                      </span>
+                      {contact.value}
+                    </div>
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Foto profesional con botones de descarga debajo */}
+          <div className="md:col-span-4 flex flex-col justify-center md:justify-end">
+            <div
+              className={`relative w-100 h-100 md:w-100 md:h-100 overflow-hidden border-4 border-white dark:border-gray-800 shadow-lg transition-all duration-700 ${photoLoaded ? "opacity-100" : "opacity-80"}`}
+            >
+              {/* Borde para estructura */}
+              <div className="absolute inset-0 border border-gray-200 dark:border-gray-700"></div>
+
+              {/* Foto - ARREGLO: Usamos directamente la imagen de los formatos modernos */}
+              <div className="w-full h-full bg-white dark:bg-gray-800">
+                {/* Usar picture para formatos modernos y fallback a placeholder si fallan */}
+                <picture>
+                  {/* Formato AVIF - más eficiente */}
+                  <source
+                    srcSet="/images/oriol_macias-sm.avif"
+                    type="image/avif"
+                  />
+                  {/* Formato WebP - amplio soporte */}
+                  <source
+                    srcSet="/images/oriol_macias-sm.webp"
+                    type="image/webp"
+                  />
+                  {/* Fallback a placeholder */}
+                  <img
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400' viewBox='0 0 400 400'%3E%3Crect width='400' height='400' fill='%23f3f4f6'/%3E%3Ctext x='50%25' y='50%25' font-family='Arial' font-size='42' text-anchor='middle' fill='%239ca3af' dominant-baseline='middle'%3EOM%3C/text%3E%3C/svg%3E"
+                    alt={localData.photoAlt}
+                    width={400}
+                    height={400}
+                    loading="eager"
+                    className="w-full h-full object-cover transition-opacity duration-500"
+                    onLoad={handleImageLoaded}
+                  />
+                </picture>
+              </div>
+
+              {/* Acento rojo */}
+              <div className="absolute bottom-0 left-0 right-0 h-2 bg-brand-red"></div>
+            </div>
+
+            {/* Botones de descarga con estilo consistente */}
+            <div className="flex flex-col sm:flex-row gap-3 mt-4 justify-center">
+              <button
+                onClick={handleCVDownload}
+                className="w-full sm:w-auto inline-flex items-center justify-center px-3 py-2 text-sm text-white bg-brand-red rounded-none hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-red focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                aria-label={localData.downloadCV}
+              >
+                <i className="fas fa-download mr-1.5"></i>
+                <span>{localData.downloadCV}</span>
+              </button>
+
+              <button
+                onClick={handleCoverLetterDownload}
+                className="w-full sm:w-auto inline-flex items-center justify-center px-3 py-2 text-sm text-white bg-brand-red rounded-none hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-red focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                aria-label={localData.downloadCoverLetter}
+              >
+                <i className="fas fa-file-alt mr-1.5"></i>
+                <span>{localData.downloadCoverLetter}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 };
 
 export default ProfileHeader;

--- a/src/components/cv/Projects.jsx
+++ b/src/components/cv/Projects.jsx
@@ -2,339 +2,409 @@
  * Projects component with simplified animations and multilingual support
  * File: src/components/cv/Projects.jsx
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import {
-    getCurrentLanguagePersonalProjects,
-    getCurrentLanguageProfessionalProjects,
-    getTechIcon
-} from '../../data/projects';
+  getCurrentLanguagePersonalProjects,
+  getCurrentLanguageProfessionalProjects,
+  getTechIcon,
+} from "../../data/projects";
 
 const Projects = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const [showAllDetails, setShowAllDetails] = useState(false);
-    const [activeTab, setActiveTab] = useState('personal'); // 'personal' or 'professional'
-    const [personalProjects, setPersonalProjects] = useState([]);
-    const [professionalProjects, setProfessionalProjects] = useState([]);
-    const [translations, setTranslations] = useState({
-        title: 'Key Projects',
-        technologies: 'Technologies',
-        keyFeatures: 'Key Features',
-        viewOnGithub: 'View on GitHub',
-        showAllDetails: 'Show all details',
-        showLessDetails: 'Show less details',
-        personalProjects: 'Personal Projects',
-        professionalWork: 'Professional Work',
-        personalProjectsNote: 'These are personal projects I\'ve developed to explore technologies and solve specific challenges.',
-        professionalProjectsNote: 'These are just some of the professional projects developed during my work at Bjumper. Repositories are private due to confidentiality agreements.'
-    });
+  const [isVisible, setIsVisible] = useState(false);
+  const [showAllDetails, setShowAllDetails] = useState(false);
+  const [activeTab, setActiveTab] = useState("personal"); // 'personal' or 'professional'
+  const [personalProjects, setPersonalProjects] = useState(() =>
+    getCurrentLanguagePersonalProjects(),
+  );
+  const [professionalProjects, setProfessionalProjects] = useState(() =>
+    getCurrentLanguageProfessionalProjects(),
+  );
 
-    // Load translations for UI elements
-    const loadTranslations = () => {
-        if (typeof window !== 'undefined' && typeof window.t === 'function') {
-            setTranslations({
-                title: window.t('projects.title') || 'Key Projects',
-                technologies: window.t('projects.technologies') || 'Technologies',
-                keyFeatures: window.t('projects.keyFeatures') || 'Key Features',
-                viewOnGithub: window.t('projects.viewOnGithub') || 'View on GitHub',
-                showAllDetails: window.t('projects.showAllDetails') || 'Show all details',
-                showLessDetails: window.t('projects.showLessDetails') || 'Show less details',
-                personalProjects: window.t('projects.personalProjects') || 'Personal Projects',
-                professionalWork: window.t('projects.professionalWork') || 'Professional Work',
-                personalProjectsNote: window.t('projects.personalProjectsNote') || 'These are personal projects I\'ve developed to explore technologies and solve specific challenges.',
-                professionalProjectsNote: window.t('projects.professionalProjectsNote') || 'These are just some of the professional projects developed during my work at Bjumper. Repositories are private due to confidentiality agreements.'
-            });
+  const getTranslation = (key, defaultValue) => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      const translated = window.t(key);
+      if (translated) return translated;
+    }
+    return defaultValue;
+  };
+
+  const [translations, setTranslations] = useState(() => ({
+    title: getTranslation("projects.title", "Key Projects"),
+    technologies: getTranslation("projects.technologies", "Technologies"),
+    keyFeatures: getTranslation("projects.keyFeatures", "Key Features"),
+    viewOnGithub: getTranslation("projects.viewOnGithub", "View on GitHub"),
+    showAllDetails: getTranslation(
+      "projects.showAllDetails",
+      "Show all details",
+    ),
+    showLessDetails: getTranslation(
+      "projects.showLessDetails",
+      "Show less details",
+    ),
+    personalProjects: getTranslation(
+      "projects.personalProjects",
+      "Personal Projects",
+    ),
+    professionalWork: getTranslation(
+      "projects.professionalWork",
+      "Professional Work",
+    ),
+    personalProjectsNote: getTranslation(
+      "projects.personalProjectsNote",
+      "These are personal projects I've developed to explore technologies and solve specific challenges.",
+    ),
+    professionalProjectsNote: getTranslation(
+      "projects.professionalProjectsNote",
+      "These are just some of the professional projects developed during my work at Bjumper. Repositories are private due to confidentiality agreements.",
+    ),
+  }));
+
+  // Load translations for UI elements
+  const loadTranslations = () => {
+    if (typeof window !== "undefined" && typeof window.t === "function") {
+      setTranslations({
+        title: window.t("projects.title") || "Key Projects",
+        technologies: window.t("projects.technologies") || "Technologies",
+        keyFeatures: window.t("projects.keyFeatures") || "Key Features",
+        viewOnGithub: window.t("projects.viewOnGithub") || "View on GitHub",
+        showAllDetails:
+          window.t("projects.showAllDetails") || "Show all details",
+        showLessDetails:
+          window.t("projects.showLessDetails") || "Show less details",
+        personalProjects:
+          window.t("projects.personalProjects") || "Personal Projects",
+        professionalWork:
+          window.t("projects.professionalWork") || "Professional Work",
+        personalProjectsNote:
+          window.t("projects.personalProjectsNote") ||
+          "These are personal projects I've developed to explore technologies and solve specific challenges.",
+        professionalProjectsNote:
+          window.t("projects.professionalProjectsNote") ||
+          "These are just some of the professional projects developed during my work at Bjumper. Repositories are private due to confidentiality agreements.",
+      });
+    }
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
         }
-    };
-
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
-                    observer.disconnect();
-                }
-            },
-            { threshold: 0.1 }
-        );
-
-        const element = document.getElementById('projects');
-        if (element) {
-            observer.observe(element);
-        }
-
-        // Load initial project data and translations
-        setPersonalProjects(getCurrentLanguagePersonalProjects());
-        setProfessionalProjects(getCurrentLanguageProfessionalProjects());
-        loadTranslations();
-
-        // Listen for language changes
-        const handleLanguageChanged = () => {
-            setPersonalProjects(getCurrentLanguagePersonalProjects());
-            setProfessionalProjects(getCurrentLanguageProfessionalProjects());
-            loadTranslations();
-        };
-
-        document.addEventListener('languageChanged', handleLanguageChanged);
-        document.addEventListener('translationsLoaded', handleLanguageChanged);
-
-        return () => {
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChanged);
-            document.removeEventListener('translationsLoaded', handleLanguageChanged);
-        };
-    }, []);
-
-    // Toggle show all project descriptions
-    const toggleAllProjectDetails = () => {
-        setShowAllDetails(!showAllDetails);
-    };
-
-    // Get the proper icon, making sure VMware has its icon
-    const getFixedIcon = (project) => {
-        if (project.id === "vmware-service" && !project.icon) {
-            return "fab fa-vmware";
-        }
-        return project.icon || "fas fa-code";
-    };
-
-    // Render a project card for personal projects (clickable to GitHub)
-    const renderPersonalProjectCard = (project, index) => (
-        <div
-            key={project.id}
-            className={`group bg-light-surface dark:bg-dark-surface rounded-none overflow-hidden border border-light-border dark:border-dark-border shadow-sm hover:shadow-md transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'} hover:translate-y-[-8px] ${project.highlight ? 'border-l-4 border-l-brand-red' : ''} h-full flex flex-col cursor-pointer`}
-            style={{ transitionDelay: `${200 * index}ms` }}
-            onClick={() => project.githubUrl && window.open(project.githubUrl, '_blank', 'noopener,noreferrer')}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter' && project.githubUrl) {
-                    window.open(project.githubUrl, '_blank', 'noopener,noreferrer');
-                }
-            }}
-            tabIndex={0}
-            role="link"
-            aria-label={`${translations.viewOnGithub}: ${project.title}`}
-        >
-            {/* Red header bar with icon */}
-            <div className="bg-brand-red p-3 flex items-center justify-between gap-3 text-white z-20 relative">
-                <div className="flex items-center gap-2">
-                    <i className={`${getFixedIcon(project)} text-xl`}></i>
-                    <h3 className="font-bold text-lg">{project.title}</h3>
-                </div>
-
-                {/* GitHub link */}
-                {project.githubUrl && (
-
-                    <a href={project.githubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-white/80 transition-colors z-30 relative"
-                        aria-label={`GitHub: ${project.title}`}
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <i className="fab fa-github text-lg"></i>
-                    </a>
-                )}
-            </div>
-
-            <div className="p-5 z-20 relative flex-grow flex flex-col">
-                <p className="mb-4 text-light-text-secondary dark:text-dark-text-secondary">
-                    {showAllDetails ? project.longDescription : project.description}
-                </p>
-
-                {/* Key Features - only visible when expanded */}
-                {showAllDetails && (
-                    <div className="mb-4 animate-fade-in">
-                        <h4 className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-2 tracking-wider" data-i18n="projects.keyFeatures">
-                            {translations.keyFeatures}
-                        </h4>
-                        <ul className="space-y-2 text-sm">
-                            {project.keyFeatures.map((feature, featureIndex) => (
-                                <li key={featureIndex} className="flex items-start gap-2">
-                                    <i className="fas fa-check text-brand-red flex-shrink-0 mt-1"></i>
-                                    <span>{feature}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
-
-                {/* Technologies used */}
-                <div className="mt-auto">
-                    <h4 className="text-xs uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-2" data-i18n="projects.technologies">
-                        {translations.technologies}
-                    </h4>
-                    <div className="flex flex-wrap gap-2 mt-2">
-                        {project.technologies.map((tech, techIndex) => (
-                            <span
-                                key={techIndex}
-                                className="px-2 py-1 text-xs border border-light-border dark:border-dark-border rounded-none 
-                                  bg-light-secondary dark:bg-dark-secondary hover:border-brand-red
-                                  transition-colors duration-150 flex items-center gap-1.5 z-20 relative"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                <i className={`${getTechIcon(tech)} text-brand-red`}></i>
-                                {tech}
-                            </span>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Click indicator */}
-                <div className="mt-3 flex items-center text-xs text-light-text-secondary dark:text-dark-text-secondary opacity-0 group-hover:opacity-100 transition-opacity z-20 relative">
-                    <i className="fas fa-external-link-alt mr-1 text-brand-red"></i>
-                    {translations.viewOnGithub}
-                </div>
-
-                {/* Bottom indicator line */}
-                <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full z-20 relative"></div>
-            </div>
-        </div>
+      },
+      { threshold: 0.1 },
     );
 
-    // Render a project card for professional projects (not clickable)
-    const renderProfessionalProjectCard = (project, index) => (
-        <div
-            key={project.id}
-            className={`group bg-light-surface dark:bg-dark-surface rounded-none overflow-hidden border border-light-border dark:border-dark-border shadow-sm hover:shadow-md transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'} hover:translate-y-[-8px] ${project.highlight ? 'border-l-4 border-l-brand-red' : ''} h-full flex flex-col`}
-            style={{ transitionDelay: `${200 * index}ms` }}
-            tabIndex={0}
-            role="article"
-            aria-label={`${project.title}`}
-        >
-            {/* Red header bar with icon */}
-            <div className="bg-brand-red p-3 flex items-center justify-between gap-3 text-white z-20 relative">
-                <div className="flex items-center gap-2">
-                    <i className={`${getFixedIcon(project)} text-xl`}></i>
-                    <h3 className="font-bold text-lg">{project.title}</h3>
-                </div>
+    const element = document.getElementById("projects");
+    if (element) {
+      observer.observe(element);
+    }
 
-                <div className="px-2 py-0.5 text-xs bg-white/20 rounded-none">
-                    {project.company}
-                </div>
-            </div>
+    // Load initial project data and translations
+    setPersonalProjects(getCurrentLanguagePersonalProjects());
+    setProfessionalProjects(getCurrentLanguageProfessionalProjects());
+    loadTranslations();
 
-            <div className="p-5 z-20 relative flex-grow flex flex-col">
-                <p className="mb-4 text-light-text-secondary dark:text-dark-text-secondary">
-                    {showAllDetails ? project.longDescription : project.description}
-                </p>
+    // Listen for language changes
+    const handleLanguageChanged = () => {
+      setPersonalProjects(getCurrentLanguagePersonalProjects());
+      setProfessionalProjects(getCurrentLanguageProfessionalProjects());
+      loadTranslations();
+    };
 
-                {/* Key Features - only visible when expanded */}
-                {showAllDetails && (
-                    <div className="mb-4 animate-fade-in">
-                        <h4 className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-2 tracking-wider" data-i18n="projects.keyFeatures">
-                            {translations.keyFeatures}
-                        </h4>
-                        <ul className="space-y-2 text-sm">
-                            {project.keyFeatures.map((feature, featureIndex) => (
-                                <li key={featureIndex} className="flex items-start gap-2">
-                                    <i className="fas fa-check text-brand-red flex-shrink-0 mt-1"></i>
-                                    <span>{feature}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
+    document.addEventListener("languageChanged", handleLanguageChanged);
+    document.addEventListener("translationsLoaded", handleLanguageChanged);
 
-                {/* Technologies used */}
-                <div className="mt-auto">
-                    <h4 className="text-xs uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-2" data-i18n="projects.technologies">
-                        {translations.technologies}
-                    </h4>
-                    <div className="flex flex-wrap gap-2 mt-2">
-                        {project.technologies.map((tech, techIndex) => (
-                            <span
-                                key={techIndex}
-                                className="px-2 py-1 text-xs border border-light-border dark:border-dark-border rounded-none 
-                                  bg-light-secondary dark:bg-dark-secondary hover:border-brand-red
-                                  transition-colors duration-150 flex items-center gap-1.5 z-20 relative"
-                            >
-                                <i className={`${getTechIcon(tech)} text-brand-red`}></i>
-                                {tech}
-                            </span>
-                        ))}
-                    </div>
-                </div>
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChanged);
+      document.removeEventListener("translationsLoaded", handleLanguageChanged);
+    };
+  }, []);
 
-                {/* Bottom indicator line */}
-                <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full z-20 relative"></div>
-            </div>
+  // Toggle show all project descriptions
+  const toggleAllProjectDetails = () => {
+    setShowAllDetails(!showAllDetails);
+  };
+
+  // Get the proper icon, making sure VMware has its icon
+  const getFixedIcon = (project) => {
+    if (project.id === "vmware-service" && !project.icon) {
+      return "fab fa-vmware";
+    }
+    return project.icon || "fas fa-code";
+  };
+
+  // Render a project card for personal projects (clickable to GitHub)
+  const renderPersonalProjectCard = (project, index) => (
+    <div
+      key={project.id}
+      className={`group bg-light-surface dark:bg-dark-surface rounded-none overflow-hidden border border-light-border dark:border-dark-border shadow-sm hover:shadow-md transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"} hover:translate-y-[-8px] ${project.highlight ? "border-l-4 border-l-brand-red" : ""} h-full flex flex-col cursor-pointer`}
+      style={{ transitionDelay: `${200 * index}ms` }}
+      onClick={() =>
+        project.githubUrl &&
+        window.open(project.githubUrl, "_blank", "noopener,noreferrer")
+      }
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && project.githubUrl) {
+          window.open(project.githubUrl, "_blank", "noopener,noreferrer");
+        }
+      }}
+      tabIndex={0}
+      role="link"
+      aria-label={`${translations.viewOnGithub}: ${project.title}`}
+    >
+      {/* Red header bar with icon */}
+      <div className="bg-brand-red p-3 flex items-center justify-between gap-3 text-white z-20 relative">
+        <div className="flex items-center gap-2">
+          <i className={`${getFixedIcon(project)} text-xl`}></i>
+          <h3 className="font-bold text-lg">{project.title}</h3>
         </div>
-    );
 
-    return (
-        <section id="projects" className="pt-4">
-            <div className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'}`}>
-                <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
-                    <i className="fas fa-project-diagram"></i>
-                </div>
-                <h2 className="text-2xl font-bold ml-3" data-i18n="projects.title">{translations.title}</h2>
+        {/* GitHub link */}
+        {project.githubUrl && (
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white/80 transition-colors z-30 relative"
+            aria-label={`GitHub: ${project.title}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <i className="fab fa-github text-lg"></i>
+          </a>
+        )}
+      </div>
 
-                {/* Toggle all projects details button */}
-                <button
-                    onClick={toggleAllProjectDetails}
-                    className="ml-auto text-brand-red hover:text-brand-red/80 text-sm inline-flex items-center gap-1 focus:outline-none"
-                >
-                    {showAllDetails ? (
-                        <>
-                            <i className="fas fa-chevron-up text-xs"></i>
-                            {translations.showLessDetails}
-                        </>
-                    ) : (
-                        <>
-                            <i className="fas fa-chevron-down text-xs"></i>
-                            {translations.showAllDetails}
-                        </>
-                    )}
-                </button>
-            </div>
+      <div className="p-5 z-20 relative flex-grow flex flex-col">
+        <p className="mb-4 text-light-text-secondary dark:text-dark-text-secondary">
+          {showAllDetails ? project.longDescription : project.description}
+        </p>
 
-            {/* Project type tabs */}
-            <div className="flex border-b border-light-border dark:border-dark-border mb-6">
-                <button
-                    onClick={() => setActiveTab('personal')}
-                    className={`py-2 px-4 font-medium text-sm ${activeTab === 'personal'
-                        ? 'text-brand-red border-b-2 border-brand-red'
-                        : 'text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red/70'}`}
-                    data-i18n="projects.personalProjects"
-                >
-                    {translations.personalProjects}
-                </button>
-                <button
-                    onClick={() => setActiveTab('professional')}
-                    className={`py-2 px-4 font-medium text-sm ${activeTab === 'professional'
-                        ? 'text-brand-red border-b-2 border-brand-red'
-                        : 'text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red/70'}`}
-                    data-i18n="projects.professionalWork"
-                >
-                    {translations.professionalWork}
-                </button>
-            </div>
-
-            {/* Project grid - conditional rendering based on active tab */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {activeTab === 'personal' ? (
-                    personalProjects.map((project, index) => renderPersonalProjectCard(project, index))
-                ) : (
-                    professionalProjects.map((project, index) => renderProfessionalProjectCard(project, index))
-                )}
-            </div>
-
-            {/* Footer note - different for each tab */}
-            <div
-                className={`mt-8 text-center transition-all duration-500 transform ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}
-                style={{ transitionDelay: '500ms' }}
+        {/* Key Features - only visible when expanded */}
+        {showAllDetails && (
+          <div className="mb-4 animate-fade-in">
+            <h4
+              className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-2 tracking-wider"
+              data-i18n="projects.keyFeatures"
             >
-                {activeTab === 'personal' ? (
-                    <p className="text-sm text-light-text-secondary dark:text-dark-text-secondary" data-i18n="projects.personalProjectsNote">
-                        {translations.personalProjectsNote}
-                    </p>
-                ) : (
-                    <p className="text-sm text-light-text-secondary dark:text-dark-text-secondary" data-i18n="projects.professionalProjectsNote">
-                        {translations.professionalProjectsNote}
-                    </p>
-                )}
-            </div>
-        </section>
-    );
+              {translations.keyFeatures}
+            </h4>
+            <ul className="space-y-2 text-sm">
+              {project.keyFeatures.map((feature, featureIndex) => (
+                <li key={featureIndex} className="flex items-start gap-2">
+                  <i className="fas fa-check text-brand-red flex-shrink-0 mt-1"></i>
+                  <span>{feature}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Technologies used */}
+        <div className="mt-auto">
+          <h4
+            className="text-xs uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-2"
+            data-i18n="projects.technologies"
+          >
+            {translations.technologies}
+          </h4>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {project.technologies.map((tech, techIndex) => (
+              <span
+                key={techIndex}
+                className="px-2 py-1 text-xs border border-light-border dark:border-dark-border rounded-none 
+                                  bg-light-secondary dark:bg-dark-secondary hover:border-brand-red
+                                  transition-colors duration-150 flex items-center gap-1.5 z-20 relative"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <i className={`${getTechIcon(tech)} text-brand-red`}></i>
+                {tech}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Click indicator */}
+        <div className="mt-3 flex items-center text-xs text-light-text-secondary dark:text-dark-text-secondary opacity-0 group-hover:opacity-100 transition-opacity z-20 relative">
+          <i className="fas fa-external-link-alt mr-1 text-brand-red"></i>
+          {translations.viewOnGithub}
+        </div>
+
+        {/* Bottom indicator line */}
+        <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full z-20 relative"></div>
+      </div>
+    </div>
+  );
+
+  // Render a project card for professional projects (not clickable)
+  const renderProfessionalProjectCard = (project, index) => (
+    <div
+      key={project.id}
+      className={`group bg-light-surface dark:bg-dark-surface rounded-none overflow-hidden border border-light-border dark:border-dark-border shadow-sm hover:shadow-md transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"} hover:translate-y-[-8px] ${project.highlight ? "border-l-4 border-l-brand-red" : ""} h-full flex flex-col`}
+      style={{ transitionDelay: `${200 * index}ms` }}
+      tabIndex={0}
+      role="article"
+      aria-label={`${project.title}`}
+    >
+      {/* Red header bar with icon */}
+      <div className="bg-brand-red p-3 flex items-center justify-between gap-3 text-white z-20 relative">
+        <div className="flex items-center gap-2">
+          <i className={`${getFixedIcon(project)} text-xl`}></i>
+          <h3 className="font-bold text-lg">{project.title}</h3>
+        </div>
+
+        <div className="px-2 py-0.5 text-xs bg-white/20 rounded-none">
+          {project.company}
+        </div>
+      </div>
+
+      <div className="p-5 z-20 relative flex-grow flex flex-col">
+        <p className="mb-4 text-light-text-secondary dark:text-dark-text-secondary">
+          {showAllDetails ? project.longDescription : project.description}
+        </p>
+
+        {/* Key Features - only visible when expanded */}
+        {showAllDetails && (
+          <div className="mb-4 animate-fade-in">
+            <h4
+              className="text-sm uppercase text-brand-red dark:text-brand-red font-semibold mb-2 tracking-wider"
+              data-i18n="projects.keyFeatures"
+            >
+              {translations.keyFeatures}
+            </h4>
+            <ul className="space-y-2 text-sm">
+              {project.keyFeatures.map((feature, featureIndex) => (
+                <li key={featureIndex} className="flex items-start gap-2">
+                  <i className="fas fa-check text-brand-red flex-shrink-0 mt-1"></i>
+                  <span>{feature}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Technologies used */}
+        <div className="mt-auto">
+          <h4
+            className="text-xs uppercase text-light-text-secondary dark:text-dark-text-secondary font-semibold mb-2"
+            data-i18n="projects.technologies"
+          >
+            {translations.technologies}
+          </h4>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {project.technologies.map((tech, techIndex) => (
+              <span
+                key={techIndex}
+                className="px-2 py-1 text-xs border border-light-border dark:border-dark-border rounded-none 
+                                  bg-light-secondary dark:bg-dark-secondary hover:border-brand-red
+                                  transition-colors duration-150 flex items-center gap-1.5 z-20 relative"
+              >
+                <i className={`${getTechIcon(tech)} text-brand-red`}></i>
+                {tech}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Bottom indicator line */}
+        <div className="w-0 h-0.5 bg-brand-red mt-4 transition-all duration-150 group-hover:w-full z-20 relative"></div>
+      </div>
+    </div>
+  );
+
+  return (
+    <section id="projects" className="pt-4">
+      <div
+        className={`flex items-center mb-6 transition-all duration-700 transform ${isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}`}
+      >
+        <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
+          <i className="fas fa-project-diagram"></i>
+        </div>
+        <h2 className="text-2xl font-bold ml-3" data-i18n="projects.title">
+          {translations.title}
+        </h2>
+
+        {/* Toggle all projects details button */}
+        <button
+          onClick={toggleAllProjectDetails}
+          className="ml-auto text-brand-red hover:text-brand-red/80 text-sm inline-flex items-center gap-1 focus:outline-none"
+        >
+          {showAllDetails ? (
+            <>
+              <i className="fas fa-chevron-up text-xs"></i>
+              {translations.showLessDetails}
+            </>
+          ) : (
+            <>
+              <i className="fas fa-chevron-down text-xs"></i>
+              {translations.showAllDetails}
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Project type tabs */}
+      <div className="flex border-b border-light-border dark:border-dark-border mb-6">
+        <button
+          onClick={() => setActiveTab("personal")}
+          className={`py-2 px-4 font-medium text-sm ${
+            activeTab === "personal"
+              ? "text-brand-red border-b-2 border-brand-red"
+              : "text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red/70"
+          }`}
+          data-i18n="projects.personalProjects"
+        >
+          {translations.personalProjects}
+        </button>
+        <button
+          onClick={() => setActiveTab("professional")}
+          className={`py-2 px-4 font-medium text-sm ${
+            activeTab === "professional"
+              ? "text-brand-red border-b-2 border-brand-red"
+              : "text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red/70"
+          }`}
+          data-i18n="projects.professionalWork"
+        >
+          {translations.professionalWork}
+        </button>
+      </div>
+
+      {/* Project grid - conditional rendering based on active tab */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {activeTab === "personal"
+          ? personalProjects.map((project, index) =>
+              renderPersonalProjectCard(project, index),
+            )
+          : professionalProjects.map((project, index) =>
+              renderProfessionalProjectCard(project, index),
+            )}
+      </div>
+
+      {/* Footer note - different for each tab */}
+      <div
+        className={`mt-8 text-center transition-all duration-500 transform ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
+        style={{ transitionDelay: "500ms" }}
+      >
+        {activeTab === "personal" ? (
+          <p
+            className="text-sm text-light-text-secondary dark:text-dark-text-secondary"
+            data-i18n="projects.personalProjectsNote"
+          >
+            {translations.personalProjectsNote}
+          </p>
+        ) : (
+          <p
+            className="text-sm text-light-text-secondary dark:text-dark-text-secondary"
+            data-i18n="projects.professionalProjectsNote"
+          >
+            {translations.professionalProjectsNote}
+          </p>
+        )}
+      </div>
+    </section>
+  );
 };
 
 export default Projects;

--- a/src/components/cv/Skills.jsx
+++ b/src/components/cv/Skills.jsx
@@ -2,303 +2,321 @@
  * Skills component with fluid animations and multilingual support
  * File: src/components/cv/Skills.jsx
  */
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef } from "react";
 // Importamos solo lo que necesitamos
-import skillsData, { getCurrentLanguageSkills } from '../../data/skills';
+import skillsData, { getCurrentLanguageSkills } from "../../data/skills";
 // Importamos getTechIcon desde el sistema unificado
-import { getTechIcon } from '../../data/icons';
+import { getTechIcon } from "../../data/icons";
 
 const Skills = () => {
-    const [isVisible, setIsVisible] = useState(false);
-    const sectionRef = useRef(null);
-    const [categories, setCategories] = useState({});
-    const [titles, setTitles] = useState({
-        main: 'Technical Skills',
-        languages: 'Programming Languages',
-        libraries: 'Libraries & Frameworks',
-        technologies: 'Technologies & Databases',
-        tools: 'Tools & Applications',
-        protocols: 'Protocols'
-    });
+  const [isVisible, setIsVisible] = useState(false);
+  const sectionRef = useRef(null);
+  const [categories, setCategories] = useState({});
+  const [titles, setTitles] = useState(() => {
+    const localized = getCurrentLanguageSkills();
+    return {
+      main: localized.title,
+      languages: localized.languages.title,
+      libraries: localized.libraries.title,
+      technologies: localized.technologies.title,
+      tools: localized.tools.title,
+      protocols: localized.protocols.title,
+    };
+  });
 
-    // Custom delays for each type of element
-    const getStaggerDelay = (index, type) => {
-        const baseDelay = {
-            'header': 30,
-            'languages': 10,
-            'libraries': 12,
-            'technologies': 16,
-            'tools': 18,
-            'protocols': 20
-        };
-
-        // Add slight random variations for a more organic effect
-        const variation = Math.random() * 10 - 5; // Between -5ms and +5ms
-        return (baseDelay[type] || 20) * index + variation;
+  // Custom delays for each type of element
+  const getStaggerDelay = (index, type) => {
+    const baseDelay = {
+      header: 30,
+      languages: 10,
+      libraries: 12,
+      technologies: 16,
+      tools: 18,
+      protocols: 20,
     };
 
-    useEffect(() => {
-        // Load initial titles based on current language
-        updateTitles();
+    // Add slight random variations for a more organic effect
+    const variation = Math.random() * 10 - 5; // Between -5ms and +5ms
+    return (baseDelay[type] || 20) * index + variation;
+  };
 
-        // IntersectionObserver configuration
-        const observer = new IntersectionObserver(
-            (entries) => {
-                const [entry] = entries;
+  useEffect(() => {
+    // Load initial titles based on current language
+    updateTitles();
 
-                if (entry.isIntersecting) {
-                    // Fluid staggered animation for different categories
-                    setIsVisible(true);
+    // IntersectionObserver configuration
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
 
-                    // Sequence of activation for categories with natural delays
-                    const sequence = ['languages', 'libraries', 'technologies', 'tools', 'protocols'];
+        if (entry.isIntersecting) {
+          // Fluid staggered animation for different categories
+          setIsVisible(true);
 
-                    // Activate categories with natural timing
-                    sequence.forEach((category, i) => {
-                        setTimeout(() => {
-                            setCategories(prev => ({
-                                ...prev,
-                                [category]: true
-                            }));
-                        }, 150 + i * 100); // Natural spacing between categories
-                    });
+          // Sequence of activation for categories with natural delays
+          const sequence = [
+            "languages",
+            "libraries",
+            "technologies",
+            "tools",
+            "protocols",
+          ];
 
-                    observer.disconnect();
-                }
-            },
-            {
-                threshold: 0.15,
-                rootMargin: "-50px 0px"
-            }
-        );
+          // Activate categories with natural timing
+          sequence.forEach((category, i) => {
+            setTimeout(
+              () => {
+                setCategories((prev) => ({
+                  ...prev,
+                  [category]: true,
+                }));
+              },
+              150 + i * 100,
+            ); // Natural spacing between categories
+          });
 
-        if (sectionRef.current) {
-            observer.observe(sectionRef.current);
+          observer.disconnect();
         }
+      },
+      {
+        threshold: 0.15,
+        rootMargin: "-50px 0px",
+      },
+    );
 
-        // Listen for language changes
-        const handleLanguageChanged = () => {
-            updateTitles();
-        };
+    if (sectionRef.current) {
+      observer.observe(sectionRef.current);
+    }
 
-        document.addEventListener('languageChanged', handleLanguageChanged);
-        document.addEventListener('translationsLoaded', handleLanguageChanged);
-
-        return () => {
-            observer.disconnect();
-            document.removeEventListener('languageChanged', handleLanguageChanged);
-            document.removeEventListener('translationsLoaded', handleLanguageChanged);
-        };
-    }, []);
-
-    // Update section titles based on current language
-    const updateTitles = () => {
-        const localizedData = getCurrentLanguageSkills();
-
-        setTitles({
-            main: localizedData.title,
-            languages: localizedData.languages.title,
-            libraries: localizedData.libraries.title,
-            technologies: localizedData.technologies.title,
-            tools: localizedData.tools.title,
-            protocols: localizedData.protocols.title
-        });
+    // Listen for language changes
+    const handleLanguageChanged = () => {
+      updateTitles();
     };
 
-    // SkillPill with fluid animations based on physics principles
-    const SkillPill = ({ name, icon, index, category }) => {
-        const isActive = categories[category] || false;
-        const delay = getStaggerDelay(index, category);
-        const hasBounce = index % 3 === 0; // Some elements will have bounce
+    document.addEventListener("languageChanged", handleLanguageChanged);
+    document.addEventListener("translationsLoaded", handleLanguageChanged);
 
-        return (
-            <div
-                className={`bg-white dark:bg-dark-surface border border-gray-200 dark:border-dark-border 
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("languageChanged", handleLanguageChanged);
+      document.removeEventListener("translationsLoaded", handleLanguageChanged);
+    };
+  }, []);
+
+  // Update section titles based on current language
+  const updateTitles = () => {
+    const localizedData = getCurrentLanguageSkills();
+
+    setTitles({
+      main: localizedData.title,
+      languages: localizedData.languages.title,
+      libraries: localizedData.libraries.title,
+      technologies: localizedData.technologies.title,
+      tools: localizedData.tools.title,
+      protocols: localizedData.protocols.title,
+    });
+  };
+
+  // SkillPill with fluid animations based on physics principles
+  const SkillPill = ({ name, icon, index, category }) => {
+    const isActive = categories[category] || false;
+    const delay = getStaggerDelay(index, category);
+    const hasBounce = index % 3 === 0; // Some elements will have bounce
+
+    return (
+      <div
+        className={`bg-white dark:bg-dark-surface border border-gray-200 dark:border-dark-border 
                         px-3 py-2 rounded-none inline-flex items-center justify-center text-sm gap-2
                         transition-all hover:border-brand-red hover:translate-x-1
                         hover:shadow-sm dark:hover:bg-gray-800 skill-pill`}
-                style={{
-                    transform: isActive ? 'translateY(0)' : `translateY(${20 + index % 10}px)`,
-                    opacity: isActive ? 1 : 0,
-                    transitionProperty: 'transform, opacity, border-color, box-shadow',
-                    transitionDuration: `${280 + index % 120}ms`,
-                    transitionDelay: `${delay}ms`,
-                    transitionTimingFunction: hasBounce
-                        ? 'cubic-bezier(0.34, 1.56, 0.64, 1)' // With bounce
-                        : 'cubic-bezier(0.33, 1, 0.68, 1)', // Without bounce
-                    transformOrigin: index % 2 === 0 ? 'left center' : 'right center'
-                }}
-            >
-                <i className={`${icon} text-brand-red`}></i>
-                <span>{name}</span>
-            </div>
-        );
-    };
+        style={{
+          transform: isActive
+            ? "translateY(0)"
+            : `translateY(${20 + (index % 10)}px)`,
+          opacity: isActive ? 1 : 0,
+          transitionProperty: "transform, opacity, border-color, box-shadow",
+          transitionDuration: `${280 + (index % 120)}ms`,
+          transitionDelay: `${delay}ms`,
+          transitionTimingFunction: hasBounce
+            ? "cubic-bezier(0.34, 1.56, 0.64, 1)" // With bounce
+            : "cubic-bezier(0.33, 1, 0.68, 1)", // Without bounce
+          transformOrigin: index % 2 === 0 ? "left center" : "right center",
+        }}
+      >
+        <i className={`${icon} text-brand-red`}></i>
+        <span>{name}</span>
+      </div>
+    );
+  };
 
-    // Section header with fluid animation
-    const SectionHeader = ({ icon, title, index, category }) => {
-        const isActive = categories[category] || false;
-        const delay = 50 + index * 80; // Progressive delay for headers
-
-        return (
-            <div
-                className="border-b border-gray-200 dark:border-gray-700 pb-3 mb-4 section-header"
-                style={{
-                    transform: isActive ? 'translateX(0)' : 'translateX(-30px)',
-                    opacity: isActive ? 1 : 0,
-                    transitionProperty: 'transform, opacity',
-                    transitionDuration: '450ms',
-                    transitionDelay: `${delay}ms`,
-                    transitionTimingFunction: 'cubic-bezier(0.33, 1, 0.68, 1)'
-                }}
-            >
-                <h3 className="text-lg font-semibold flex items-center gap-2">
-                    <div className="w-8 h-8 bg-brand-red bg-opacity-10 flex items-center justify-center rounded-none">
-                        <i className={`${icon} text-brand-red`}></i>
-                    </div>
-                    {title}
-                </h3>
-            </div>
-        );
-    };
+  // Section header with fluid animation
+  const SectionHeader = ({ icon, title, index, category }) => {
+    const isActive = categories[category] || false;
+    const delay = 50 + index * 80; // Progressive delay for headers
 
     return (
-        <section id="skills" ref={sectionRef} className="mb-16">
-            {/* Section Header with optimized animation */}
-            <div
-                className="flex items-center mb-6"
-                style={{
-                    transform: isVisible ? 'translateY(0)' : 'translateY(20px)',
-                    opacity: isVisible ? 1 : 0,
-                    transition: 'transform 600ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 500ms ease-out'
-                }}
-            >
-                <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
-                    <i className="fas fa-code"></i>
-                </div>
-                <h2 className="text-2xl font-bold ml-3" data-i18n="skills.title">{titles.main}</h2>
-            </div>
-
-            {/* Main container with optimized appearance effect */}
-            <div
-                className="bg-white dark:bg-dark-surface p-6 border border-gray-200 dark:border-dark-border rounded-none shadow-sm"
-                style={{
-                    transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-                    opacity: isVisible ? 1 : 0,
-                    transition: 'transform 500ms cubic-bezier(0.33, 1, 0.68, 1), opacity 400ms ease-out',
-                    transitionDelay: '100ms'
-                }}
-            >
-                {/* Layout with natural gap */}
-                <div className="grid grid-cols-1 gap-8">
-                    {/* Programming Languages */}
-                    <div className="space-y-4">
-                        <SectionHeader
-                            icon="fas fa-code"
-                            title={titles.languages}
-                            index={0}
-                            category="languages"
-                        />
-                        <div className="flex flex-wrap gap-3">
-                            {skillsData.languages.map((skill, index) => (
-                                <SkillPill
-                                    key={skill.id}
-                                    name={skill.name}
-                                    icon={skill.icon}
-                                    index={index}
-                                    category="languages"
-                                />
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Libraries & Frameworks */}
-                    <div className="space-y-4 pt-2">
-                        <SectionHeader
-                            icon="fas fa-puzzle-piece"
-                            title={titles.libraries}
-                            index={1}
-                            category="libraries"
-                        />
-                        <div className="flex flex-wrap gap-3">
-                            {skillsData.libraries.map((lib, index) => (
-                                <SkillPill
-                                    key={lib.id}
-                                    name={lib.name}
-                                    icon={lib.icon}
-                                    index={index}
-                                    category="libraries"
-                                />
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Technologies & Databases */}
-                    <div className="space-y-4 pt-2">
-                        <SectionHeader
-                            icon="fas fa-server"
-                            title={titles.technologies}
-                            index={2}
-                            category="technologies"
-                        />
-                        <div className="flex flex-wrap gap-3">
-                            {skillsData.technologies.map((tech, index) => (
-                                <SkillPill
-                                    key={tech.id}
-                                    name={tech.name}
-                                    icon={tech.icon}
-                                    index={index}
-                                    category="technologies"
-                                />
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Tools & Applications */}
-                    <div className="space-y-4 pt-2">
-                        <SectionHeader
-                            icon="fas fa-tools"
-                            title={titles.tools}
-                            index={3}
-                            category="tools"
-                        />
-                        <div className="flex flex-wrap gap-3">
-                            {skillsData.tools.map((tool, index) => (
-                                <SkillPill
-                                    key={tool.id}
-                                    name={tool.name}
-                                    icon={tool.icon}
-                                    index={index}
-                                    category="tools"
-                                />
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Protocols */}
-                    <div className="space-y-4 pt-2">
-                        <SectionHeader
-                            icon="fas fa-network-wired"
-                            title={titles.protocols}
-                            index={4}
-                            category="protocols"
-                        />
-                        <div className="flex flex-wrap gap-3">
-                            {skillsData.protocols.map((protocol, index) => (
-                                <SkillPill
-                                    key={protocol.id}
-                                    name={protocol.name}
-                                    icon={protocol.icon}
-                                    index={index}
-                                    category="protocols"
-                                />
-                            ))}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
+      <div
+        className="border-b border-gray-200 dark:border-gray-700 pb-3 mb-4 section-header"
+        style={{
+          transform: isActive ? "translateX(0)" : "translateX(-30px)",
+          opacity: isActive ? 1 : 0,
+          transitionProperty: "transform, opacity",
+          transitionDuration: "450ms",
+          transitionDelay: `${delay}ms`,
+          transitionTimingFunction: "cubic-bezier(0.33, 1, 0.68, 1)",
+        }}
+      >
+        <h3 className="text-lg font-semibold flex items-center gap-2">
+          <div className="w-8 h-8 bg-brand-red bg-opacity-10 flex items-center justify-center rounded-none">
+            <i className={`${icon} text-brand-red`}></i>
+          </div>
+          {title}
+        </h3>
+      </div>
     );
+  };
+
+  return (
+    <section id="skills" ref={sectionRef} className="mb-16">
+      {/* Section Header with optimized animation */}
+      <div
+        className="flex items-center mb-6"
+        style={{
+          transform: isVisible ? "translateY(0)" : "translateY(20px)",
+          opacity: isVisible ? 1 : 0,
+          transition:
+            "transform 600ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 500ms ease-out",
+        }}
+      >
+        <div className="w-10 h-10 flex items-center justify-center bg-brand-red text-white rounded-none">
+          <i className="fas fa-code"></i>
+        </div>
+        <h2 className="text-2xl font-bold ml-3" data-i18n="skills.title">
+          {titles.main}
+        </h2>
+      </div>
+
+      {/* Main container with optimized appearance effect */}
+      <div
+        className="bg-white dark:bg-dark-surface p-6 border border-gray-200 dark:border-dark-border rounded-none shadow-sm"
+        style={{
+          transform: isVisible ? "translateY(0)" : "translateY(30px)",
+          opacity: isVisible ? 1 : 0,
+          transition:
+            "transform 500ms cubic-bezier(0.33, 1, 0.68, 1), opacity 400ms ease-out",
+          transitionDelay: "100ms",
+        }}
+      >
+        {/* Layout with natural gap */}
+        <div className="grid grid-cols-1 gap-8">
+          {/* Programming Languages */}
+          <div className="space-y-4">
+            <SectionHeader
+              icon="fas fa-code"
+              title={titles.languages}
+              index={0}
+              category="languages"
+            />
+            <div className="flex flex-wrap gap-3">
+              {skillsData.languages.map((skill, index) => (
+                <SkillPill
+                  key={skill.id}
+                  name={skill.name}
+                  icon={skill.icon}
+                  index={index}
+                  category="languages"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Libraries & Frameworks */}
+          <div className="space-y-4 pt-2">
+            <SectionHeader
+              icon="fas fa-puzzle-piece"
+              title={titles.libraries}
+              index={1}
+              category="libraries"
+            />
+            <div className="flex flex-wrap gap-3">
+              {skillsData.libraries.map((lib, index) => (
+                <SkillPill
+                  key={lib.id}
+                  name={lib.name}
+                  icon={lib.icon}
+                  index={index}
+                  category="libraries"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Technologies & Databases */}
+          <div className="space-y-4 pt-2">
+            <SectionHeader
+              icon="fas fa-server"
+              title={titles.technologies}
+              index={2}
+              category="technologies"
+            />
+            <div className="flex flex-wrap gap-3">
+              {skillsData.technologies.map((tech, index) => (
+                <SkillPill
+                  key={tech.id}
+                  name={tech.name}
+                  icon={tech.icon}
+                  index={index}
+                  category="technologies"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Tools & Applications */}
+          <div className="space-y-4 pt-2">
+            <SectionHeader
+              icon="fas fa-tools"
+              title={titles.tools}
+              index={3}
+              category="tools"
+            />
+            <div className="flex flex-wrap gap-3">
+              {skillsData.tools.map((tool, index) => (
+                <SkillPill
+                  key={tool.id}
+                  name={tool.name}
+                  icon={tool.icon}
+                  index={index}
+                  category="tools"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Protocols */}
+          <div className="space-y-4 pt-2">
+            <SectionHeader
+              icon="fas fa-network-wired"
+              title={titles.protocols}
+              index={4}
+              category="protocols"
+            />
+            <div className="flex flex-wrap gap-3">
+              {skillsData.protocols.map((protocol, index) => (
+                <SkillPill
+                  key={protocol.id}
+                  name={protocol.name}
+                  icon={protocol.icon}
+                  index={index}
+                  category="protocols"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default Skills;


### PR DESCRIPTION
## Summary
- keep translation and content in sync between SSR and client render
- initialize CV section state from data modules
- use safe translation helper during setup

## Testing
- `npx prettier --write src/components/cv/Education.jsx src/components/cv/Experience.jsx src/components/cv/Languages.jsx src/components/cv/ProfileHeader.jsx src/components/cv/Projects.jsx src/components/cv/Skills.jsx`
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*
- `npm run dev` *(fails: getaddrinfo ENOTFOUND cdnjs.cloudflare.com)*