### PR TITLE
Optimize Font Awesome loading

### DIFF
--- a/public/scripts/font-awesome-loader.js
+++ b/public/scripts/font-awesome-loader.js
@@ -2,98 +2,78 @@
  * Font Awesome Loader - Script unificado
  * Maneja la carga de Font Awesome con fallbacks robustos
  */
-(function() {
-    // Configuración
-    const FA_VERSION = '6.4.0';
-    const CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/' + FA_VERSION + '/css/all.min.css';
-    const LOCAL_URL = '/styles/font-awesome-minimal.css';
-    const FALLBACK_URL = '/styles/font-awesome-fallback.css';
-    const INTEGRITY = 'sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==';
+(function () {
+  // Configuración
+  const FA_VERSION = "6.4.0";
+  const OPTIMIZED_URL = "/styles/font-awesome-optimized.css";
+  const LOCAL_URL = "/styles/font-awesome-minimal.css";
+  const FALLBACK_URL = "/styles/font-awesome-fallback.css";
 
-    // Función para cargar CSS con manejo de errores
-    function loadCSS(url, integrity = null, crossorigin = null) {
-        return new Promise((resolve, reject) => {
-            const link = document.createElement('link');
-            link.rel = 'stylesheet';
-            link.href = url;
+  // Función para cargar CSS con manejo de errores
+  function loadCSS(url, integrity = null, crossorigin = null) {
+    return new Promise((resolve, reject) => {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = url;
 
-            if (integrity) {
-                link.integrity = integrity;
-                link.crossOrigin = crossorigin || 'anonymous';
-            }
+      if (integrity) {
+        link.integrity = integrity;
+        link.crossOrigin = crossorigin || "anonymous";
+      }
 
-            link.onload = () => {
-                console.log('[Font Awesome] Cargado: ' + url);
-                resolve(link);
-            };
+      link.onload = () => {
+        console.log("[Font Awesome] Cargado: " + url);
+        resolve(link);
+      };
 
-            link.onerror = () => {
-                console.warn('[Font Awesome] Error cargando: ' + url);
-                reject(new Error('Failed to load ' + url));
-            };
+      link.onerror = () => {
+        console.warn("[Font Awesome] Error cargando: " + url);
+        reject(new Error("Failed to load " + url));
+      };
 
-            document.head.appendChild(link);
-        });
-    }
+      document.head.appendChild(link);
+    });
+  }
 
-    // Estrategia de carga: fallback → minimal → CDN
-    loadCSS(FALLBACK_URL)
-        .then(() => {
-            // Luego carga minimal (optimizado)
-            return loadCSS(LOCAL_URL);
+  // Estrategia de carga: fallback → minimal → optimizada
+  loadCSS(FALLBACK_URL)
+    .then(() => loadCSS(LOCAL_URL))
+    .then(() => loadCSS(OPTIMIZED_URL))
+    .then(() => {
+      document.documentElement.classList.add("fa-loaded");
+    })
+    .catch((error) => {
+      console.error("[Font Awesome] Error cargando estilos locales:", error);
+      injectFallbackIcons();
+    });
+
+  // Verificar que las fuentes existan localmente
+  const REQUIRED_FONTS = [
+    "/styles/fonts/fa-solid-900.woff2",
+    "/styles/fonts/fa-brands-400.woff2",
+  ];
+
+  Promise.all(
+    REQUIRED_FONTS.map((fontUrl) =>
+      fetch(fontUrl, { method: "HEAD" })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("Font file " + fontUrl + " not available");
+          }
+          return true;
         })
-        .then(() => {
-            // Finalmente intenta cargar CDN completo
-            return loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .then(() => {
-                    document.documentElement.classList.add('fa-loaded');
-                })
-                .catch(error => {
-                    console.warn('[Font Awesome] Usando solo versión local');
-                    document.documentElement.classList.add('fa-minimal');
-                });
-        })
-        .catch(error => {
-            console.error('[Font Awesome] Error en carga principal, intentando CDN:', error);
-            
-            // Intento directo desde CDN como fallback
-            loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .then(() => {
-                    document.documentElement.classList.add('fa-loaded');
-                })
-                .catch(error => {
-                    console.error('[Font Awesome] Fallo completo. Usando emojis fallback:', error);
-                    injectFallbackIcons();
-                });
-        });
+        .catch((error) => {
+          console.warn("[Font Awesome] " + error.message);
+          return false;
+        }),
+    ),
+  ).then((results) => {
+    if (!results.every((result) => result === true)) {
+      console.warn("[Font Awesome] Algunas fuentes faltan, usando fuentes CDN");
 
-    // Verificar que las fuentes existan localmente
-    const REQUIRED_FONTS = [
-        '/styles/fonts/fa-solid-900.woff2',
-        '/styles/fonts/fa-brands-400.woff2'
-    ];
-
-    Promise.all(
-        REQUIRED_FONTS.map(fontUrl =>
-            fetch(fontUrl, { method: 'HEAD' })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error('Font file ' + fontUrl + ' not available');
-                    }
-                    return true;
-                })
-                .catch(error => {
-                    console.warn('[Font Awesome] ' + error.message);
-                    return false;
-                })
-        )
-    ).then(results => {
-        if (!results.every(result => result === true)) {
-            console.warn('[Font Awesome] Algunas fuentes faltan, usando fuentes CDN');
-            
-            // Fuentes CDN como fallback
-            const style = document.createElement('style');
-            style.textContent = `
+      // Fuentes CDN como fallback
+      const style = document.createElement("style");
+      style.textContent = `
                 @font-face {
                     font-family: 'Font Awesome 5 Free';
                     font-style: normal;
@@ -110,14 +90,14 @@
                     src: url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2') format('woff2');
                 }
             `;
-            document.head.appendChild(style);
-        }
-    });
+      document.head.appendChild(style);
+    }
+  });
 
-    // Último recurso: emojis unicode como fallback
-    function injectFallbackIcons() {
-        const style = document.createElement('style');
-        style.textContent = `
+  // Último recurso: emojis unicode como fallback
+  function injectFallbackIcons() {
+    const style = document.createElement("style");
+    style.textContent = `
             .fas, .fab { display: inline-block; width: 1em; height: 1em; }
             .fa-user:before { content: "👤"; }
             .fa-envelope:before { content: "✉️"; }
@@ -128,7 +108,7 @@
             .fa-graduation-cap:before { content: "🎓"; }
             .fa-language:before { content: "🌐"; }
         `;
-        document.head.appendChild(style);
-        document.documentElement.classList.add('fa-fallback');
-    }
+    document.head.appendChild(style);
+    document.documentElement.classList.add("fa-fallback");
+  }
 })();

--- a/public/styles/font-awesome-loader.js
+++ b/public/styles/font-awesome-loader.js
@@ -2,65 +2,48 @@
  * Font Awesome Loader
  * Estrategia de carga optimizada con fallbacks
  */
-(function() {
-    // Configuración
-    const FA_VERSION = '6.4.0';
-    const CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/' + FA_VERSION + '/css/all.min.css';
-    const LOCAL_URL = '/styles/font-awesome-minimal.css';
-    const FALLBACK_URL = '/styles/font-awesome-fallback.css';
-    const INTEGRITY = 'sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==';
+(function () {
+  // Configuración
+  const FA_VERSION = "6.4.0";
+  const OPTIMIZED_URL = "/styles/font-awesome-optimized.css";
+  const LOCAL_URL = "/styles/font-awesome-minimal.css";
+  const FALLBACK_URL = "/styles/font-awesome-fallback.css";
 
-    // Función para cargar CSS con manejo de errores
-    function loadCSS(url, integrity, crossorigin) {
-        return new Promise((resolve, reject) => {
-            const link = document.createElement('link');
-            link.rel = 'stylesheet';
-            link.href = url;
+  // Función para cargar CSS con manejo de errores
+  function loadCSS(url, integrity, crossorigin) {
+    return new Promise((resolve, reject) => {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = url;
 
-            if (integrity) {
-                link.integrity = integrity;
-                link.crossOrigin = crossorigin || 'anonymous';
-            }
+      if (integrity) {
+        link.integrity = integrity;
+        link.crossOrigin = crossorigin || "anonymous";
+      }
 
-            link.onload = () => resolve(link);
-            link.onerror = () => reject(new Error('Failed to load ' + url));
+      link.onload = () => resolve(link);
+      link.onerror = () => reject(new Error("Failed to load " + url));
 
-            document.head.appendChild(link);
-        });
-    }
+      document.head.appendChild(link);
+    });
+  }
 
-    // Cargar fallback primero (garantiza iconos básicos)
-    loadCSS(FALLBACK_URL)
-        .then(() => {
-            // Luego cargar versión mínima local
-            return loadCSS(LOCAL_URL);
-        })
-        .then(() => {
-            // Finalmente intentar cargar versión completa desde CDN
-            return loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .then(() => {
-                    document.documentElement.classList.add('fa-loaded');
-                })
-                .catch(() => {
-                    // Si falla CDN, ya tenemos las versiones mínimas
-                    document.documentElement.classList.add('fa-minimal');
-                });
-        })
-        .catch(error => {
-            console.error('Font Awesome error:', error);
-            
-            // Intentar directamente CDN como último recurso
-            loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .catch(() => {
-                    // Si todo falla, inyectar estilos con emojis
-                    injectFallbackIcons();
-                });
-        });
+  // Cargar fallback primero (garantiza iconos básicos)
+  loadCSS(FALLBACK_URL)
+    .then(() => loadCSS(LOCAL_URL))
+    .then(() => loadCSS(OPTIMIZED_URL))
+    .then(() => {
+      document.documentElement.classList.add("fa-loaded");
+    })
+    .catch((error) => {
+      console.error("Font Awesome error:", error);
+      injectFallbackIcons();
+    });
 
-    // Último recurso: emojis unicode
-    function injectFallbackIcons() {
-        const style = document.createElement('style');
-        style.textContent = `
+  // Último recurso: emojis unicode
+  function injectFallbackIcons() {
+    const style = document.createElement("style");
+    style.textContent = `
             .fas, .fab { display: inline-block; width: 1em; height: 1em; }
             .fa-user:before { content: "👤"; }
             .fa-envelope:before { content: "✉️"; }
@@ -71,7 +54,7 @@
             .fa-graduation-cap:before { content: "🎓"; }
             .fa-language:before { content: "🌐"; }
         `;
-        document.head.appendChild(style);
-        document.documentElement.classList.add('fa-fallback');
-    }
+    document.head.appendChild(style);
+    document.documentElement.classList.add("fa-fallback");
+  }
 })();

--- a/scripts/font-awesome-loader.js
+++ b/scripts/font-awesome-loader.js
@@ -4,97 +4,77 @@
  * Maneja la carga de Font Awesome con fallbacks robustos
  */
 (function () {
-    // Configuración
-    const FA_VERSION = '6.4.0';
-    const CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/' + FA_VERSION + '/css/all.min.css';
-    const LOCAL_URL = '/styles/font-awesome-minimal.css';
-    const FALLBACK_URL = '/styles/font-awesome-fallback.css';
-    const INTEGRITY = 'sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==';
+  // Configuración
+  const FA_VERSION = "6.4.0";
+  const OPTIMIZED_URL = "/styles/font-awesome-optimized.css";
+  const LOCAL_URL = "/styles/font-awesome-minimal.css";
+  const FALLBACK_URL = "/styles/font-awesome-fallback.css";
 
-    // Función para cargar CSS con manejo de errores
-    function loadCSS(url, integrity = null, crossorigin = null) {
-        return new Promise((resolve, reject) => {
-            const link = document.createElement('link');
-            link.rel = 'stylesheet';
-            link.href = url;
+  // Función para cargar CSS con manejo de errores
+  function loadCSS(url, integrity = null, crossorigin = null) {
+    return new Promise((resolve, reject) => {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = url;
 
-            if (integrity) {
-                link.integrity = integrity;
-                link.crossOrigin = crossorigin || 'anonymous';
-            }
+      if (integrity) {
+        link.integrity = integrity;
+        link.crossOrigin = crossorigin || "anonymous";
+      }
 
-            link.onload = () => {
-                console.log('[Font Awesome] Cargado: ' + url);
-                resolve(link);
-            };
+      link.onload = () => {
+        console.log("[Font Awesome] Cargado: " + url);
+        resolve(link);
+      };
 
-            link.onerror = () => {
-                console.warn('[Font Awesome] Error cargando: ' + url);
-                reject(new Error('Failed to load ' + url));
-            };
+      link.onerror = () => {
+        console.warn("[Font Awesome] Error cargando: " + url);
+        reject(new Error("Failed to load " + url));
+      };
 
-            document.head.appendChild(link);
-        });
-    }
+      document.head.appendChild(link);
+    });
+  }
 
-    // Estrategia de carga: fallback → minimal → CDN
-    loadCSS(FALLBACK_URL)
-        .then(() => {
-            // Luego carga minimal (optimizado)
-            return loadCSS(LOCAL_URL);
+  // Estrategia de carga: fallback → minimal → optimizada
+  loadCSS(FALLBACK_URL)
+    .then(() => loadCSS(LOCAL_URL))
+    .then(() => loadCSS(OPTIMIZED_URL))
+    .then(() => {
+      document.documentElement.classList.add("fa-loaded");
+    })
+    .catch((error) => {
+      console.error("[Font Awesome] Error cargando estilos locales:", error);
+      injectFallbackIcons();
+    });
+
+  // Verificar que las fuentes existan localmente
+  const REQUIRED_FONTS = [
+    "/styles/fonts/fa-solid-900.woff2",
+    "/styles/fonts/fa-brands-400.woff2",
+  ];
+
+  Promise.all(
+    REQUIRED_FONTS.map((fontUrl) =>
+      fetch(fontUrl, { method: "HEAD" })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("Font file " + fontUrl + " not available");
+          }
+          return true;
         })
-        .then(() => {
-            // Finalmente intenta cargar CDN completo
-            return loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .then(() => {
-                    document.documentElement.classList.add('fa-loaded');
-                })
-                .catch(error => {
-                    console.warn('[Font Awesome] Usando solo versión local');
-                    document.documentElement.classList.add('fa-minimal');
-                });
-        })
-        .catch(error => {
-            console.error('[Font Awesome] Error en carga principal, intentando CDN:', error);
+        .catch((error) => {
+          console.warn("[Font Awesome] " + error.message);
+          return false;
+        }),
+    ),
+  ).then((results) => {
+    if (!results.every((result) => result === true)) {
+      console.warn("[Font Awesome] Algunas fuentes faltan, usando fuentes CDN");
 
-            // Intento directo desde CDN como fallback
-            loadCSS(CDN_URL, INTEGRITY, 'anonymous')
-                .then(() => {
-                    document.documentElement.classList.add('fa-loaded');
-                })
-                .catch(error => {
-                    console.error('[Font Awesome] Fallo completo. Usando emojis fallback:', error);
-                    injectFallbackIcons();
-                });
-        });
-
-    // Verificar que las fuentes existan localmente
-    const REQUIRED_FONTS = [
-        '/styles/fonts/fa-solid-900.woff2',
-        '/styles/fonts/fa-brands-400.woff2'
-    ];
-
-    Promise.all(
-        REQUIRED_FONTS.map(fontUrl =>
-            fetch(fontUrl, { method: 'HEAD' })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error('Font file ' + fontUrl + ' not available');
-                    }
-                    return true;
-                })
-                .catch(error => {
-                    console.warn('[Font Awesome] ' + error.message);
-                    return false;
-                })
-        )
-    ).then(results => {
-        if (!results.every(result => result === true)) {
-            console.warn('[Font Awesome] Algunas fuentes faltan, usando fuentes CDN');
-
-            // Fuentes CDN como fallback
-            const style = document.createElement('style');
-            style.textContent = `
+      // Fuentes CDN como fallback
+      const style = document.createElement("style");
+      style.textContent = `
                 @font-face {
                     font-family: 'Font Awesome 5 Free';
                     font-style: normal;
@@ -111,14 +91,14 @@
                     src: url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2') format('woff2');
                 }
             `;
-            document.head.appendChild(style);
-        }
-    });
+      document.head.appendChild(style);
+    }
+  });
 
-    // Último recurso: emojis unicode como fallback
-    function injectFallbackIcons() {
-        const style = document.createElement('style');
-        style.textContent = `
+  // Último recurso: emojis unicode como fallback
+  function injectFallbackIcons() {
+    const style = document.createElement("style");
+    style.textContent = `
             .fas, .fab { display: inline-block; width: 1em; height: 1em; }
             .fa-user:before { content: "👤"; }
             .fa-envelope:before { content: "✉️"; }
@@ -129,7 +109,7 @@
             .fa-graduation-cap:before { content: "🎓"; }
             .fa-language:before { content: "🌐"; }
         `;
-        document.head.appendChild(style);
-        document.documentElement.classList.add('fa-fallback');
-    }
+    document.head.appendChild(style);
+    document.documentElement.classList.add("fa-fallback");
+  }
 })();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -450,12 +450,10 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
           `;
               document.head.appendChild(style);
 
-              // Cargar CSS completo desde CDN como respaldo
+              // Cargar versión optimizada local como respaldo
               const link = document.createElement("link");
               link.rel = "stylesheet";
-              link.href =
-                "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css";
-              link.crossOrigin = "anonymous";
+              link.href = "/styles/font-awesome-optimized.css";
               document.head.appendChild(link);
             }
           }, 500); // Esperar 500ms para comprobar


### PR DESCRIPTION
## Summary
- load only optimized font-awesome css in loader scripts
- drop CDN all.min.css fallback in layout

## Testing
- `npx prettier --write public/scripts/font-awesome-loader.js public/styles/font-awesome-loader.js scripts/font-awesome-loader.js`
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*