### PR TITLE
Add preload for hero image

### DIFF
--- a/src/components/cv/ProfileHeader.jsx
+++ b/src/components/cv/ProfileHeader.jsx
@@ -217,6 +217,7 @@ const ProfileHeader = () => {
                                         width={400}
                                         height={400}
                                         loading="eager"
+                                        fetchpriority="high"
                                         className="w-full h-full object-cover transition-opacity duration-500"
                                         onLoad={handleImageLoaded}
                                     />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,6 +43,16 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
     <link
       rel="preload"
       as="image"
+      href="/images/oriol_macias-sm.avif"
+      imagesrcset="
+      /images/oriol_macias-sm.avif 400w,
+      /images/oriol_macias-md.avif 800w,
+      /images/oriol_macias-lg.avif 1200w
+    "
+    />
+    <link
+      rel="preload"
+      as="image"
       href="/images/oriol_macias-640.avif"
       imagesrcset="
       /images/oriol_macias-192.avif 192w,


### PR DESCRIPTION
## Summary
- preload hero image in Layout
- hint to high priority when loading ProfileHeader image

## Testing
- `npx prettier --check src/components/cv/ProfileHeader.jsx`
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*
