### PR TITLE
Fix brand red contrast in dark mode

### DIFF
--- a/src/styles/enhanced-contrast-fix.css
+++ b/src/styles/enhanced-contrast-fix.css
@@ -4,91 +4,96 @@
 /* ===== CORRECCIONES PARA MODO CLARO ===== */
 body:not(.dark) h4.text-brand-red,
 body:not(.dark) [data-i18n="experience.keyAchievements"] {
-    color: #AB1F1F !important;
-    /* Rojo más oscuro y accesible */
-    font-weight: 700 !important;
+  color: #ab1f1f !important;
+  /* Rojo más oscuro y accesible */
+  font-weight: 700 !important;
 }
 
 body:not(.dark) .text-light-text-secondary {
-    color: #4B5563 !important;
-    /* Más oscuro para mejor contraste */
+  color: #4b5563 !important;
+  /* Más oscuro para mejor contraste */
 }
 
 body:not(.dark) nav [data-section],
 body:not(.dark) nav a {
-    color: #111827 !important;
-    /* Casi negro para navegación */
+  color: #111827 !important;
+  /* Casi negro para navegación */
 }
 
 body:not(.dark) nav [data-section="about"],
 body:not(.dark) nav [aria-current="page"] {
-    color: #AB1F1F !important;
-    /* Rojo más oscuro para elementos activos */
+  color: #ab1f1f !important;
+  /* Rojo más oscuro para elementos activos */
 }
 
 /* ===== CORRECCIONES PARA MODO OSCURO ===== */
 .dark h4.text-brand-red,
 .dark [data-i18n="experience.keyAchievements"] {
-    color: #FF6B6B !important;
-    /* Rojo más claro para modo oscuro */
-    font-weight: 700 !important;
+  color: #ff6b6b !important;
+  /* Rojo más claro para modo oscuro */
+  font-weight: 700 !important;
 }
 
 .dark .text-dark-text-secondary {
-    color: #D1D5DB !important;
-    /* Más claro para mejor contraste */
+  color: #d1d5db !important;
+  /* Más claro para mejor contraste */
 }
 
 .dark nav [data-section],
 .dark nav a {
-    color: #F9FAFB !important;
-    /* Casi blanco para navegación */
+  color: #f9fafb !important;
+  /* Casi blanco para navegación */
 }
 
 .dark nav [data-section="about"],
 .dark nav [aria-current="page"] {
-    color: #FF6B6B !important;
-    /* Rojo más claro para elementos activos */
+  color: #ff6b6b !important;
+  /* Rojo más claro para elementos activos */
 }
 
 /* ===== CORRECCIONES GENERALES ===== */
 .text-brand-red {
-    color: #B22222 !important;
-    /* Fallback general */
+  color: #b22222 !important;
+  /* Fallback general para fondos claros */
+}
+
+.dark .text-brand-red {
+  color: #ff6b6b !important;
+  /* Mayor contraste en modo oscuro */
 }
 
 .bg-brand-red {
-    background-color: #B22222 !important;
-    /* Mantener consistencia */
+  background-color: #b22222 !important;
+  /* Mantener consistencia */
 }
 
 /* Asegurar que las tarjetas en la sección de experiencia tengan buen contraste */
 .bg-light-surface,
 .dark .bg-dark-surface {
-    border: 1px solid currentColor !important;
-    border-color: rgba(0, 0, 0, 0.1) !important;
+  border: 1px solid currentColor !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
 }
 
 .dark .bg-dark-surface {
-    border-color: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
 }
 
 /* Pestañas de proyectos */
 body:not(.dark) [data-i18n="projects.personalProjects"],
 body:not(.dark) [data-i18n="projects.professionalWork"] {
-    color: #111827 !important;
-    font-weight: 600 !important;
+  color: #111827 !important;
+  font-weight: 600 !important;
 }
 
 .dark [data-i18n="projects.personalProjects"],
 .dark [data-i18n="projects.professionalWork"] {
-    color: #F9FAFB !important;
-    font-weight: 600 !important;
+  color: #f9fafb !important;
+  font-weight: 600 !important;
 }
 
 /* Etiquetas NATIVE en la sección de idiomas */
 .bg-brand-red.text-white {
-    color: white !important;
-    background-color: #AB1F1F !important;
-    font-weight: bold !important;
+  color: white !important;
+  background-color: #ab1f1f !important;
+  font-weight: bold !important;
 }


### PR DESCRIPTION
## Summary
- improve `.text-brand-red` contrast when the site is in dark mode

## Testing
- `npx prettier --check src/styles/enhanced-contrast-fix.css`
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*