### PR TITLE
Fix extraneous CDN snippet in Font Awesome minimal CSS

### DIFF
--- a/public/styles/font-awesome-minimal.css
+++ b/public/styles/font-awesome-minimal.css
@@ -67,7 +67,3 @@
     src: local('Arial');
     unicode-range: U+F000-F2FF;
 }
-
-< !-- Font Awesome - load local minimal version first as a fallback --><link rel="stylesheet" href="/styles/font-awesome-minimal.css" />< !-- Then load from CDN with integrity and cross-origin attributes --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
-crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/src/styles/font-awesome-minimal.css
+++ b/src/styles/font-awesome-minimal.css
@@ -67,7 +67,3 @@
     src: local('Arial');
     unicode-range: U+F000-F2FF;
 }
-
-< !-- Font Awesome - load local minimal version first as a fallback --><link rel="stylesheet" href="/styles/font-awesome-minimal.css" />< !-- Then load from CDN with integrity and cross-origin attributes --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
-crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
## Summary
- remove leftover CDN `<link>` snippet from `font-awesome-minimal.css`

## Testing
- `npx prettier --check src/styles/font-awesome-minimal.css public/styles/font-awesome-minimal.css`
- `npx prettier --check .`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*