### PR TITLE
Add email DNS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ LinkedIn: [linkedin.com/in/oriolmaciasbadosa](https://linkedin.com/in/oriolmacia
 
 GitHub: [github.com/MaciWP](https://github.com/MaciWP)
 
+Para configurar los registros SPF y DMARC de tu dominio puedes consultar
+[docs/email-dns.md](docs/email-dns.md).
+
 ---
 
 ❤️ Thanks for checking out my project!

--- a/docs/email-dns.md
+++ b/docs/email-dns.md
@@ -1,0 +1,25 @@
+# Configurar registros DNS para el correo
+
+Para que tu dominio pueda enviar y recibir correos de forma fiable, debes añadir los siguientes registros DNS en el panel de tu proveedor de dominio:
+
+1. **SPF**
+
+   ```txt
+   v=spf1 include:_spf.google.com ~all
+   ```
+
+   Este registro autoriza a Google Workspace a enviar correos en nombre de tu dominio.
+
+2. **DMARC**
+
+   ```txt
+   v=DMARC1; p=none; rua=mailto:dmarc@oriolmacias.dev; pct=100
+   ```
+
+   Ayuda a monitorizar la autenticación del correo y a recibir informes en `dmarc@oriolmacias.dev`.
+
+3. **DKIM (opcional para Google Workspace)**
+
+   Google recomienda habilitar DKIM para firmar tus mensajes. Puedes generar la clave desde la consola de administración de Google Workspace y añadir el registro `TXT` correspondiente en tu DNS.
+
+Guarda los cambios y espera a que la propagación del DNS se complete.


### PR DESCRIPTION
## Summary
- document SPF, DMARC and optional DKIM in `docs/email-dns.md`
- link the DNS instructions from `README.md`

## Testing
- `npx prettier --write README.md docs/email-dns.md`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*