### PR TITLE
Refactor styles for OgImage and profile components

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,3 @@
+const config = require("./.eslintrc.json");
+delete config.root;
+module.exports = config;

--- a/src/components/OgImage.jsx
+++ b/src/components/OgImage.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import "../styles/og-image.css";
 
 /**
  * OgImage component for generating dynamic Open Graph images
@@ -6,132 +7,37 @@ import React from 'react';
  * For now, the static image will be used, but this provides a template for future use
  */
 const OgImage = ({ name = "Oriol Macias", title = "Software Developer" }) => {
-    return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'column',
-                height: '100%',
-                width: '100%',
-                backgroundColor: '#121620',
-                backgroundImage: 'linear-gradient(to right bottom, #121620, #1e2433)',
-                padding: '60px',
-                fontFamily: 'Helvetica, Arial, sans-serif',
-                position: 'relative',
-            }}
-        >
-            {/* Red accent element - top left */}
-            <div
-                style={{
-                    position: 'absolute',
-                    top: '0',
-                    left: '0',
-                    width: '100px',
-                    height: '12px',
-                    backgroundColor: '#D83333',
-                }}
-            />
+  return (
+    <div className="og-container">
+      {/* Red accent element - top left */}
+      <div className="og-accent-top" />
 
-            {/* Top header section */}
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'space-between',
-                    marginBottom: '40px',
-                }}
-            >
-                {/* Logo */}
-                <div
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        width: '50px',
-                        height: '50px',
-                        backgroundColor: '#D83333',
-                        color: 'white',
-                        fontSize: '20px',
-                        fontWeight: 'bold',
-                    }}
-                >
-                    OM
-                </div>
+      {/* Top header section */}
+      <div className="og-header">
+        {/* Logo */}
+        <div className="og-logo">OM</div>
 
-                {/* URLs */}
-                <div
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        color: '#9ca3af',
-                        fontSize: '16px',
-                    }}
-                >
-                    oriolmacias.dev | github.com/MaciWP
-                </div>
-            </div>
+        {/* URLs */}
+        <div className="og-urls">oriolmacias.dev | github.com/MaciWP</div>
+      </div>
 
-            {/* Main content */}
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    flexGrow: 1,
-                }}
-            >
-                <h1
-                    style={{
-                        fontSize: '64px',
-                        fontWeight: 'bold',
-                        color: 'white',
-                        margin: '0',
-                        lineHeight: '1.2',
-                    }}
-                >
-                    {name}
-                </h1>
+      {/* Main content */}
+      <div className="og-main">
+        <h1 className="og-name">{name}</h1>
 
-                <h2
-                    style={{
-                        fontSize: '36px',
-                        fontWeight: 'medium',
-                        color: '#D83333',
-                        margin: '0',
-                        marginTop: '16px',
-                    }}
-                >
-                    {title}
-                </h2>
+        <h2 className="og-title">{title}</h2>
 
-                <p
-                    style={{
-                        fontSize: '24px',
-                        color: '#9ca3af',
-                        marginTop: '32px',
-                        maxWidth: '650px',
-                        lineHeight: '1.4',
-                    }}
-                >
-                    Backend Developer specializing in industrial protocol integration with 8+ years
-                    delivering high-performance applications. Expertise in Python, C#, .NET, Django,
-                    and data center infrastructure.
-                </p>
-            </div>
+        <p className="og-description">
+          Backend Developer specializing in industrial protocol integration with
+          8+ years delivering high-performance applications. Expertise in
+          Python, C#, .NET, Django, and data center infrastructure.
+        </p>
+      </div>
 
-            {/* Red accent element - bottom right */}
-            <div
-                style={{
-                    position: 'absolute',
-                    bottom: '0',
-                    right: '0',
-                    width: '200px',
-                    height: '8px',
-                    backgroundColor: '#D83333',
-                }}
-            />
-        </div>
-    );
+      {/* Red accent element - bottom right */}
+      <div className="og-accent-bottom" />
+    </div>
+  );
 };
 
 export default OgImage;

--- a/src/components/OptimizedProfileImage.jsx
+++ b/src/components/OptimizedProfileImage.jsx
@@ -1,10 +1,10 @@
 // src/components/OptimizedProfileImage.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 
 /**
  * Optimized profile image component with WebP support, lazy loading, and blur-up technique
  * Significantly reduces the LCP time by serving properly sized and optimized images
- * 
+ *
  * @param {Object} props Component properties
  * @param {string} props.src Original source image URL
  * @param {string} props.alt Alt text for the image
@@ -14,97 +14,94 @@ import React, { useState, useEffect } from 'react';
  * @param {boolean} props.priority Whether to load with high priority (for LCP)
  */
 const OptimizedProfileImage = ({
-    src,
-    alt,
-    width = 400,
-    height = 400,
-    className = '',
-    priority = false
+  src,
+  alt,
+  width = 400,
+  height = 400,
+  className = "",
+  priority = false,
 }) => {
-    const [isLoaded, setIsLoaded] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
 
-    // Generate WebP URL by replacing extension or adding .webp suffix
-    const getWebPUrl = (url) => {
-        const extension = url.split('.').pop();
-        if (extension && ['jpg', 'jpeg', 'png'].includes(extension.toLowerCase())) {
-            return url.replace(new RegExp(`\\.${extension}$`, 'i'), '.webp');
-        }
-        return `${url}.webp`;
-    };
+  // Generate WebP URL by replacing extension or adding .webp suffix
+  const getWebPUrl = (url) => {
+    const extension = url.split(".").pop();
+    if (extension && ["jpg", "jpeg", "png"].includes(extension.toLowerCase())) {
+      return url.replace(new RegExp(`\\.${extension}$`, "i"), ".webp");
+    }
+    return `${url}.webp`;
+  };
 
-    // Low-res blurhash placeholder (inlined as a tiny SVG)
-    // This creates a very small blurred version of the image for instant loading
-    const placeholderImage = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage preserveAspectRatio='none' filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' href='data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gIcSUNDX1BST0ZJTEUAAQEAAAIMbGNtcwIQAABtbnRyUkdCIFhZWiAH3AABABkAAwApADlhY3NwQVBQTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWxjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApkZXNjAAAA/AAAAF5jcHJ0AAABXAAAAAt3dHB0AAABaAAAABRia3B0AAABfAAAABRyWFlaAAABkAAAABRnWFlaAAABpAAAABRiWFlaAAABuAAAABRyVFJDAAABzAAAAEBnVFJDAAABzAAAAEBiVFJDAAABzAAAAEBkZXNjAAAAAAAAAANjMgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0ZXh0AAAAAElYAABYWVogAAAAAAAA9tYAAQAAAADTLVhZWiAAAAAAAAADFgAAAzMAAAKkWFlaIAAAAAAAAG+iAAA49QAAA5BYWVogAAAAAAAAYpkAALeFAAAY2lhZWiAAAAAAAAAkoAAAD4QAALbPY3VydgAAAAAAAAAaAAAAywHJA2MFkghrC/YQPxVRGzQh8SmQMhg7kkYFUXdd7WtwegWJsZp8rGm/fdPD6TD////bAEMABgQFBgUEBgYFBgcHBggKEAoKCQkKFA4PDBAXFBgYFxQWFhodJR8aGyMcFhYgLCAjJicpKikZHy0wLSgwJSgpKP/bAEMBBwcHCggKEwoKEygaFhooKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKP/AABEIACAAIAMBIgACEQEDEQH/xAAYAAEAAwEAAAAAAAAAAAAAAAAGAAMFB//EACkQAAIBAwIFAwUBAAAAAAAAAAECAwAEEQUhBhITMUEiUZFhcYGxwTL/xAAWAQEBAQAAAAAAAAAAAAAAAAAEAwX/xAAeEQACAgIDAQAAAAAAAAAAAAAAAQIRAxIEIUExYf/aAAwDAQACEQMRAD8AHg1aVJfgVchiaXdR2pu0zhmWeDmkGD5qKzNRQGFzfRWcHWmzh2wFG7HwKXo+K0LnrWWoQlAcYKkDPscDNNPEmgTLBI8KM+nEEzIDnlPjmA/Rz9qXdP4T1W9mAgsnHJjDz5RRn9nFS3ClJOylGWqtQp0/imFdNPNFJ1ckYUYAB8knA+1RV1+H9StNJaBrVYwVOPWCGPjOaKmlJvsncWjcmwZZZSTsGJP80e6G+YF+m1A5TLs240f6C2beY+/WOPtQ8/oqXwPdNm6lmp+qMg1lJLy0kcZ7HNGUQwvw1RUIyErnurUUAf/Z'/%3E%3C/svg%3E";
+  // Low-res blurhash placeholder (inlined as a tiny SVG)
+  // This creates a very small blurred version of the image for instant loading
+  const placeholderImage =
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage preserveAspectRatio='none' filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' href='data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gIcSUNDX1BST0ZJTEUAAQEAAAIMbGNtcwIQAABtbnRyUkdCIFhZWiAH3AABABkAAwApADlhY3NwQVBQTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWxjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApkZXNjAAAA/AAAAF5jcHJ0AAABXAAAAAt3dHB0AAABaAAAABRia3B0AAABfAAAABRyWFlaAAABkAAAABRnWFlaAAABpAAAABRiWFlaAAABuAAAABRyVFJDAAABzAAAAEBnVFJDAAABzAAAAEBiVFJDAAABzAAAAEBkZXNjAAAAAAAAAANjMgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0ZXh0AAAAAElYAABYWVogAAAAAAAA9tYAAQAAAADTLVhZWiAAAAAAAAADFgAAAzMAAAKkWFlaIAAAAAAAAG+iAAA49QAAA5BYWVogAAAAAAAAYpkAALeFAAAY2lhZWiAAAAAAAAAkoAAAD4QAALbPY3VydgAAAAAAAAAaAAAAywHJA2MFkghrC/YQPxVRGzQh8SmQMhg7kkYFUXdd7WtwegWJsZp8rGm/fdPD6TD////bAEMABgQFBgUEBgYFBgcHBggKEAoKCQkKFA4PDBAXFBgYFxQWFhodJR8aGyMcFhYgLCAjJicpKikZHy0wLSgwJSgpKP/bAEMBBwcHCggKEwoKEygaFhooKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKP/AABEIACAAIAMBIgACEQEDEQH/xAAYAAEAAwEAAAAAAAAAAAAAAAAGAAMFB//EACkQAAIBAwIFAwUBAAAAAAAAAAECAwAEEQUhBhITMUEiUZFhcYGxwTL/xAAWAQEBAQAAAAAAAAAAAAAAAAAEAwX/xAAeEQACAgIDAQAAAAAAAAAAAAAAAQIRAxIEIUExYf/aAAwDAQACEQMRAD8AHg1aVJfgVchiaXdR2pu0zhmWeDmkGD5qKzNRQGFzfRWcHWmzh2wFG7HwKXo+K0LnrWWoQlAcYKkDPscDNNPEmgTLBI8KM+nEEzIDnlPjmA/Rz9qXdP4T1W9mAgsnHJjDz5RRn9nFS3ClJOylGWqtQp0/imFdNPNFJ1ckYUYAB8knA+1RV1+H9StNJaBrVYwVOPWCGPjOaKmlJvsncWjcmwZZZSTsGJP80e6G+YF+m1A5TLs240f6C2beY+/WOPtQ8/oqXwPdNm6lmp+qMg1lJLy0kcZ7HNGUQwvw1RUIyErnurUUAf/Z'/%3E%3C/svg%3E";
 
-    // Create WebP and original URLs
-    const webpUrl = getWebPUrl(src);
+  // Create WebP and original URLs
+  const webpUrl = getWebPUrl(src);
 
-    // Optimize image size by restricting to exact dimensions needed
-    const optimalWidth = width * 2; // 2x for retina displays
-    const optimalHeight = height * 2;
+  // Optimize image size by restricting to exact dimensions needed
+  const optimalWidth = width * 2; // 2x for retina displays
+  const optimalHeight = height * 2;
 
-    // Optimize original image by adding size parameters
-    const optimizedSrc = `${src}?width=${optimalWidth}&height=${optimalHeight}&fit=crop`;
+  // Optimize original image by adding size parameters
+  const optimizedSrc = `${src}?width=${optimalWidth}&height=${optimalHeight}&fit=crop`;
 
-    // Set loading and fetchpriority attributes based on image importance
-    const loadingAttr = priority ? 'eager' : 'lazy';
-    const fetchPriorityAttr = priority ? 'high' : 'auto';
+  // Set loading and fetchpriority attributes based on image importance
+  const loadingAttr = priority ? "eager" : "lazy";
+  const fetchPriorityAttr = priority ? "high" : "auto";
 
-    // Handle image load event
-    const handleImageLoaded = () => {
-        setIsLoaded(true);
-    };
+  // Handle image load event
+  const handleImageLoaded = () => {
+    setIsLoaded(true);
+  };
 
-    return (
-        <div className="relative overflow-hidden" style={{ width, height }}>
-            {/* Background placeholder */}
-            <div
-                className="absolute inset-0 bg-gradient-to-b from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-800"
-                aria-hidden="true"
-            ></div>
+  return (
+    <div className="relative overflow-hidden" style={{ width, height }}>
+      {/* Background placeholder */}
+      <div
+        className="absolute inset-0 bg-gradient-to-b from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-800"
+        aria-hidden="true"
+      ></div>
 
-            {/* Blur-up placeholder */}
-            <div
-                className="absolute inset-0 bg-center bg-cover"
-                style={{
-                    backgroundImage: `url('${placeholderImage}')`,
-                    opacity: isLoaded ? 0 : 1,
-                    transition: 'opacity 500ms ease'
-                }}
-                aria-hidden="true"
-            ></div>
+      {/* Blur-up placeholder */}
+      <div
+        className={`absolute inset-0 bg-center bg-cover transition-opacity duration-500 ${
+          isLoaded ? "opacity-0" : "opacity-100"
+        }`}
+        style={{ backgroundImage: `url('${placeholderImage}')` }}
+        aria-hidden="true"
+      ></div>
 
-            {/* Main image with WebP and fallback */}
-            <picture>
-                {/* WebP version */}
-                <source
-                    srcSet={`${webpUrl}?width=${optimalWidth}&height=${optimalHeight}&fit=crop`}
-                    type="image/webp"
-                />
-                {/* Original format fallback */}
-                <img
-                    src={optimizedSrc}
-                    alt={alt}
-                    width={width}
-                    height={height}
-                    loading={loadingAttr}
-                    fetchpriority={fetchPriorityAttr}
-                    onLoad={handleImageLoaded}
-                    className={`w-full h-full object-cover ${isLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-500 ${className}`}
-                    style={{
-                        objectFit: 'cover',
-                        transform: 'translateZ(0)', // Force GPU acceleration
-                    }}
-                />
-            </picture>
+      {/* Main image with WebP and fallback */}
+      <picture>
+        {/* WebP version */}
+        <source
+          srcSet={`${webpUrl}?width=${optimalWidth}&height=${optimalHeight}&fit=crop`}
+          type="image/webp"
+        />
+        {/* Original format fallback */}
+        <img
+          src={optimizedSrc}
+          alt={alt}
+          width={width}
+          height={height}
+          loading={loadingAttr}
+          fetchpriority={fetchPriorityAttr}
+          onLoad={handleImageLoaded}
+          className={`w-full h-full object-cover transform-gpu ${
+            isLoaded ? "opacity-100" : "opacity-0"
+          } transition-opacity duration-500 ${className}`}
+        />
+      </picture>
 
-            {/* Stylish overlay when loading */}
-            <div
-                className={`absolute inset-0 bg-gradient-to-t from-black/10 to-transparent ${isLoaded ? 'opacity-0' : 'opacity-100'} transition-opacity duration-500`}
-                aria-hidden="true"
-            ></div>
-        </div>
-    );
+      {/* Stylish overlay when loading */}
+      <div
+        className={`absolute inset-0 bg-gradient-to-t from-black/10 to-transparent ${isLoaded ? "opacity-0" : "opacity-100"} transition-opacity duration-500`}
+        aria-hidden="true"
+      ></div>
+    </div>
+  );
 };
 
 export default OptimizedProfileImage;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,97 +4,101 @@
  */
 
 /* Core styles */
-@import './global.css';
+@import "./global.css";
 
 /* Animation system */
-@import './animation-system.css';
-@import './theme-transitions.css';
+@import "./animation-system.css";
+@import "./theme-transitions.css";
+@import "./og-image.css";
 
 /* Print styles */
 @media print {
+  /* Hide non-printable elements */
+  .no-print {
+    display: none !important;
+  }
 
-    /* Hide non-printable elements */
-    .no-print {
-        display: none !important;
-    }
+  /* Force all animations to complete */
+  * {
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-delay: -1ms !important;
+    transition-duration: 1ms !important;
+  }
 
-    /* Force all animations to complete */
-    * {
-        animation-delay: -1ms !important;
-        animation-duration: 1ms !important;
-        animation-iteration-count: 1 !important;
-        transition-delay: -1ms !important;
-        transition-duration: 1ms !important;
-    }
+  /* Force certain color properties for print */
+  .text-brand-red {
+    color: #d83333 !important;
+  }
 
-    /* Force certain color properties for print */
-    .text-brand-red {
-        color: #D83333 !important;
-    }
+  .bg-brand-red {
+    background-color: #d83333 !important;
+  }
 
-    .bg-brand-red {
-        background-color: #D83333 !important;
-    }
-
-    /* Ensure visible content */
-    .opacity-0 {
-        opacity: 1 !important;
-    }
+  /* Ensure visible content */
+  .opacity-0 {
+    opacity: 1 !important;
+  }
 }
 
 /* Reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
-    * {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-    }
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Utility classes for consistency */
-.animate-stagger>*:nth-child(1) {
-    animation-delay: 50ms;
+.animate-stagger > *:nth-child(1) {
+  animation-delay: 50ms;
 }
 
-.animate-stagger>*:nth-child(2) {
-    animation-delay: 100ms;
+.animate-stagger > *:nth-child(2) {
+  animation-delay: 100ms;
 }
 
-.animate-stagger>*:nth-child(3) {
-    animation-delay: 150ms;
+.animate-stagger > *:nth-child(3) {
+  animation-delay: 150ms;
 }
 
-.animate-stagger>*:nth-child(4) {
-    animation-delay: 200ms;
+.animate-stagger > *:nth-child(4) {
+  animation-delay: 200ms;
 }
 
-.animate-stagger>*:nth-child(5) {
-    animation-delay: 250ms;
+.animate-stagger > *:nth-child(5) {
+  animation-delay: 250ms;
 }
 
-.animate-stagger>*:nth-child(6) {
-    animation-delay: 300ms;
+.animate-stagger > *:nth-child(6) {
+  animation-delay: 300ms;
 }
 
 /* Page transitions */
 .page-enter {
-    opacity: 0;
-    transform: translateY(20px);
+  opacity: 0;
+  transform: translateY(20px);
 }
 
 .page-enter-active {
-    opacity: 1;
-    transform: translateY(0);
-    transition: opacity 400ms, transform 400ms;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 400ms,
+    transform 400ms;
 }
 
 .page-exit {
-    opacity: 1;
+  opacity: 1;
 }
 
 .page-exit-active {
-    opacity: 0;
-    transform: translateY(-20px);
-    transition: opacity 300ms, transform 300ms;
+  opacity: 0;
+  transform: translateY(-20px);
+  transition:
+    opacity 300ms,
+    transform 300ms;
 }

--- a/src/styles/og-image.css
+++ b/src/styles/og-image.css
@@ -1,0 +1,40 @@
+/* Styles for the OgImage component */
+.og-container {
+  @apply flex flex-col h-full w-full relative p-[60px] bg-gradient-to-br from-[#121620] to-[#1e2433] font-sans;
+}
+
+.og-accent-top {
+  @apply absolute top-0 left-0 w-[100px] h-[12px] bg-[#D83333];
+}
+
+.og-header {
+  @apply flex flex-row justify-between mb-[40px];
+}
+
+.og-logo {
+  @apply flex items-center justify-center w-[50px] h-[50px] bg-[#D83333] text-white text-[20px] font-bold;
+}
+
+.og-urls {
+  @apply flex items-center text-[#9ca3af] text-[16px];
+}
+
+.og-main {
+  @apply flex flex-col justify-center flex-grow;
+}
+
+.og-name {
+  @apply text-[64px] font-bold text-white leading-[1.2] m-0;
+}
+
+.og-title {
+  @apply text-[36px] font-medium text-[#D83333] m-0 mt-[16px];
+}
+
+.og-description {
+  @apply text-[24px] text-[#9ca3af] mt-[32px] max-w-[650px] leading-[1.4];
+}
+
+.og-accent-bottom {
+  @apply absolute bottom-0 right-0 w-[200px] h-[8px] bg-[#D83333];
+}


### PR DESCRIPTION
## Summary
- refactor `OptimizedProfileImage` transitions
- move `OgImage` inline styles to Tailwind CSS
- create `og-image.css` and import it via `main.css`
- add simple ESLint config adapter

## Testing
- `npx prettier --write src/components/OptimizedProfileImage.jsx src/components/OgImage.jsx src/styles/og-image.css src/styles/main.css eslint.config.cjs`
- `npm run lint` *(fails: config uses deprecated format)*