### PR TITLE
Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -81,7 +81,7 @@
   [headers.values]
     X-Content-Type-Options = "nosniff"
     X-XSS-Protection = "1; mode=block"
-    X-Frame-Options = "DENY"
+    X-Frame-Options = "SAMEORIGIN"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
     Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; img-src 'self' data:; font-src 'self' https://cdnjs.cloudflare.com data:; connect-src 'self'; manifest-src 'self';"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 import SkipToContent from "../components/SkipToContent";
 import A11yAnnouncer from "../components/A11yAnnouncer";
 import LanguageAlternates from "../components/LanguageAlternates";
+import SecurityHeaders from "../components/SecurityHeaders.astro";
 
 // Define props interface
 export interface Props {
@@ -106,6 +107,7 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
     <meta name="description" content={description} />
     <meta name="author" content="Oriol Macias" />
     <link rel="canonical" href={fullCanonicalUrl} />
+    <SecurityHeaders />
 
     <!-- Enlaces hreflang corregidos -->
     <LanguageAlternates


### PR DESCRIPTION
## Summary
- include SecurityHeaders component in site layout
- set `X-Frame-Options` header to `SAMEORIGIN`

## Testing
- `npx prettier --check src/layouts/Layout.astro netlify.toml --ignore-unknown`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*