### PR TITLE
Add Facebook Pixel with consent banner

### DIFF
--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from "react";
+
+const CookieBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem("pixel_consent");
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem("pixel_consent", "granted");
+    setVisible(false);
+    document.dispatchEvent(new CustomEvent("pixel-consent-granted"));
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-gray-900 text-white p-4 flex flex-col sm:flex-row items-center justify-between text-sm z-50">
+      <span className="mb-2 sm:mb-0">
+        This site uses cookies to improve your experience.
+      </span>
+      <button
+        onClick={accept}
+        className="px-3 py-1 bg-brand-red text-white rounded-none"
+      >
+        Accept
+      </button>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 import SkipToContent from "../components/SkipToContent";
 import A11yAnnouncer from "../components/A11yAnnouncer";
 import LanguageAlternates from "../components/LanguageAlternates";
+import CookieBanner from "../components/CookieBanner";
 
 // Define props interface
 export interface Props {
@@ -35,6 +36,7 @@ const {
 const fullCanonicalUrl = canonicalUrl.startsWith("http")
   ? canonicalUrl
   : new URL(Astro.url.pathname, "https://oriolmacias.dev").href;
+const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
 ---
 
 <!doctype html>
@@ -577,6 +579,7 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
           </footer>
         </ErrorBoundary>
       </I18nLoader>
+      <CookieBanner client:load />
     </div>
     <script is:inline src="/scripts/react-error-recovery.js"></script>
   </body><!-- Script for smooth scrolling to sections -->
@@ -656,7 +659,44 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
         );
       }
     });
-  </script>
+</script>
+
+  {import.meta.env.PROD && (
+    <script is:inline define:vars={{ pixelId }}>
+      {`
+      window.initPixel = function () {
+        if (!window.fbq && pixelId) {
+          !(function (f, b, e, v, n, t, s) {
+            if (f.fbq) return;
+            n = f.fbq = function () {
+              n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+            };
+            if (!f._fbq) f._fbq = n;
+            n.push = n;
+            n.loaded = !0;
+            n.version = '2.0';
+            n.queue = [];
+            t = b.createElement(e);
+            t.async = !0;
+            t.src = v;
+            s = b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t, s);
+          })(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', pixelId);
+          fbq('track', 'PageView');
+          document.getElementById('cv-download-button')?.addEventListener('click', () => {
+            fbq('track', 'Lead');
+          });
+        }
+      };
+      if (localStorage.getItem('pixel_consent') === 'granted') {
+        window.initPixel();
+      } else {
+        document.addEventListener('pixel-consent-granted', () => window.initPixel(), { once: true });
+      }
+    `}
+    </script>
+  )}
 
   <!-- Service Worker Registration - Only for production -->
   <script is:inline>


### PR DESCRIPTION
## Summary
- add `CookieBanner` React component to request tracking consent
- integrate Pixel ID from environment and load Meta Pixel only in production
- track `PageView` and `Lead` (download button click)
- show banner in layout and initialize Pixel after consent

## Testing
- `npx prettier --check src/layouts/Layout.astro src/components/CookieBanner.jsx`
- `npm run lint` *(fails: ESLint couldn't find a config)*