### PR TITLE
Add lazy loading attribute to placeholder image

### DIFF
--- a/src/components/ResponsiveProfileImage.tsx
+++ b/src/components/ResponsiveProfileImage.tsx
@@ -1,17 +1,17 @@
 // src/components/ResponsiveProfileImage.tsx
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo } from "react";
 
 type Props = {
-    /** Ruta base de la imagen sin extensión (ej: "/images/oriol_macias") */
-    src: string;
-    /** Texto alternativo accesible */
-    alt: string;
-    /** Anchuras generadas en el _build_ (por defecto 192-1 280 px) */
-    widths?: number[];
-    /** Clases tailwind extra */
-    className?: string;
-    /** ¿Es la imagen hero/LCP? */
-    priority?: boolean;
+  /** Ruta base de la imagen sin extensión (ej: "/images/oriol_macias") */
+  src: string;
+  /** Texto alternativo accesible */
+  alt: string;
+  /** Anchuras generadas en el _build_ (por defecto 192-1 280 px) */
+  widths?: number[];
+  /** Clases tailwind extra */
+  className?: string;
+  /** ¿Es la imagen hero/LCP? */
+  priority?: boolean;
 };
 
 /**
@@ -22,63 +22,66 @@ type Props = {
  *  • Funciona igual en desktop y móvil (sin sniffing)
  */
 const ResponsiveProfileImage: React.FC<Props> = ({
-    src,
-    alt,
-    widths = [192, 320, 640, 960, 1280],
-    className = '',
-    priority = false,
+  src,
+  alt,
+  widths = [192, 320, 640, 960, 1280],
+  className = "",
+  priority = false,
 }) => {
-    const [loaded, setLoaded] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
-    /* Pre-computamos srcset sólo 1 vez */
-    const { avif, webp, fallback, tiny } = useMemo(() => {
-        const build = (ext: string) =>
-            widths.map((w) => `${src}-${w}.${ext} ${w}w`).join(', ');
-        return {
-            avif: build('avif'),
-            webp: build('webp'),
-            fallback: build('jpg'),
-            tiny: `${src}-tiny.jpg`, // 20 px – placeholder
-        };
-    }, [src, widths]);
+  /* Pre-computamos srcset sólo 1 vez */
+  const { avif, webp, fallback, tiny } = useMemo(() => {
+    const build = (ext: string) =>
+      widths.map((w) => `${src}-${w}.${ext} ${w}w`).join(", ");
+    return {
+      avif: build("avif"),
+      webp: build("webp"),
+      fallback: build("jpg"),
+      tiny: `${src}-tiny.jpg`, // 20 px – placeholder
+    };
+  }, [src, widths]);
 
-    /** 100 vw < 768 px, 400 px resto  */
-    const sizes = '(max-width: 767px) 100vw, 400px';
+  /** 100 vw < 768 px, 400 px resto  */
+  const sizes = "(max-width: 767px) 100vw, 400px";
 
-    return (
-        <div
-            className={`relative overflow-hidden rounded-full ${className}`}
-            style={{ width: 400, height: 400 }}
-        >
-            {/* Blur placeholder */}
-            <img
-                src={tiny}
-                aria-hidden
-                className={`absolute inset-0 w-full h-full object-cover blur-lg scale-105 transition-opacity duration-500 ${loaded ? 'opacity-0' : 'opacity-100'
-                    }`}
-                decoding="async"
-            />
-            <picture>
-                <source type="image/avif" srcSet={avif} sizes={sizes} />
-                <source type="image/webp" srcSet={webp} sizes={sizes} />
-                <img
-                    src={`${src}-640.jpg`}
-                    srcSet={fallback}
-                    sizes={sizes}
-                    width={400}
-                    height={400}
-                    alt={alt}
-                    loading={priority ? 'eager' : 'lazy'}
-                    fetchPriority={priority ? 'high' : 'auto'}
-                    decoding="async"
-                    onLoad={() => setLoaded(true)}
-                    className={`w-full h-full object-cover transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'
-                        }`}
-                    style={{ transform: 'translateZ(0)' }}
-                />
-            </picture>
-        </div>
-    );
+  return (
+    <div
+      className={`relative overflow-hidden rounded-full ${className}`}
+      style={{ width: 400, height: 400 }}
+    >
+      {/* Blur placeholder */}
+      <img
+        src={tiny}
+        aria-hidden
+        className={`absolute inset-0 w-full h-full object-cover blur-lg scale-105 transition-opacity duration-500 ${
+          loaded ? "opacity-0" : "opacity-100"
+        }`}
+        loading="lazy"
+        decoding="async"
+      />
+      <picture>
+        <source type="image/avif" srcSet={avif} sizes={sizes} />
+        <source type="image/webp" srcSet={webp} sizes={sizes} />
+        <img
+          src={`${src}-640.jpg`}
+          srcSet={fallback}
+          sizes={sizes}
+          width={400}
+          height={400}
+          alt={alt}
+          loading={priority ? "eager" : "lazy"}
+          fetchPriority={priority ? "high" : "auto"}
+          decoding="async"
+          onLoad={() => setLoaded(true)}
+          className={`w-full h-full object-cover transition-opacity duration-500 ${
+            loaded ? "opacity-100" : "opacity-0"
+          }`}
+          style={{ transform: "translateZ(0)" }}
+        />
+      </picture>
+    </div>
+  );
 };
 
 export default ResponsiveProfileImage;


### PR DESCRIPTION
## Summary
- apply `loading="lazy"` to the blurred placeholder image in `ResponsiveProfileImage`

## Testing
- `npx prettier --check src/components/ResponsiveProfileImage.tsx`
- `npm run lint` *(fails: ESLint couldn't find a config)*