### PR TITLE
Add astro-compress integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,8 @@
 // astro.config.mjs
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
-import react from '@astrojs/react';
+import { defineConfig } from "astro/config";
+import tailwind from "@astrojs/tailwind";
+import react from "@astrojs/react";
+import compress from "astro-compress";
 
 export default defineConfig({
   i18n: {
@@ -15,9 +16,10 @@ export default defineConfig({
   integrations: [
     tailwind({
       applyBaseStyles: false,
-      config: { path: './tailwind.config.js' },
+      config: { path: "./tailwind.config.js" },
     }),
     react(),
+    compress({ gzip: true, brotli: true }),
   ],
 
   // Configuración explícita de MIME types para corregir errores
@@ -27,16 +29,16 @@ export default defineConfig({
       "*.js": [
         {
           key: "Content-Type",
-          value: "application/javascript; charset=utf-8"
-        }
+          value: "application/javascript; charset=utf-8",
+        },
       ],
       "*.css": [
         {
           key: "Content-Type",
-          value: "text/css; charset=utf-8"
-        }
-      ]
-    }
+          value: "text/css; charset=utf-8",
+        },
+      ],
+    },
   },
 
   vite: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import js from "@eslint/js";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import astro from "eslint-plugin-astro";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.{js,jsx,ts,tsx,astro}"],
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+      "jsx-a11y": jsxA11y,
+      astro,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    settings: { react: { version: "detect" } },
+  },
+];


### PR DESCRIPTION
## Summary
- import `astro-compress`
- enable Brotli and Gzip in `astro.config.mjs`
- add basic ESLint flat config so lint can run with ESLint v9

## Testing
- `npx prettier --check astro.config.mjs eslint.config.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*