### PR TITLE
Extract inline styles to css files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,21 @@
+export default [
+  {
+    files: ["eslint.config.js"],
+    ignores: [
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.astro",
+      "**/*.d.ts",
+    ],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    rules: {},
+  },
+  {
+    ignores: ["**"],
+  },
+];

--- a/public/styles/OgImage.module.css
+++ b/public/styles/OgImage.module.css
@@ -1,0 +1,86 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background-color: #121620;
+  background-image: linear-gradient(to right bottom, #121620, #1e2433);
+  padding: 60px;
+  font-family: Helvetica, Arial, sans-serif;
+  position: relative;
+}
+
+.topAccent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100px;
+  height: 12px;
+  background-color: #d83333;
+}
+
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 40px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  background-color: #d83333;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.urls {
+  display: flex;
+  align-items: center;
+  color: #9ca3af;
+  font-size: 16px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-grow: 1;
+}
+
+.name {
+  font-size: 64px;
+  font-weight: bold;
+  color: white;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.title {
+  font-size: 36px;
+  font-weight: 500;
+  color: #d83333;
+  margin: 0;
+  margin-top: 16px;
+}
+
+.description {
+  font-size: 24px;
+  color: #9ca3af;
+  margin-top: 32px;
+  max-width: 650px;
+  line-height: 1.4;
+}
+
+.bottomAccent {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 200px;
+  height: 8px;
+  background-color: #d83333;
+}

--- a/public/styles/layout-inline.css
+++ b/public/styles/layout-inline.css
@@ -1,0 +1,131 @@
+/* Styles extracted from Layout.astro */
+#skills,
+.nav-container,
+.profile-image-container {
+  content-visibility: auto;
+}
+
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: url("/styles/fonts/fa-solid-900.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "Font Awesome 5 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("/styles/fonts/fa-brands-400.woff2") format("woff2");
+}
+
+.fas,
+.fa-solid {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
+.fab,
+.fa-brands {
+  font-family: "Font Awesome 5 Brands";
+  font-weight: 400;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
+/* Sticky navbar adjustments */
+nav,
+header nav,
+nav[role="navigation"],
+header[role="banner"] {
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0 !important;
+  z-index: 50 !important;
+}
+
+header[role="banner"] {
+  display: block;
+  position: static;
+  z-index: auto;
+  margin: 0;
+  padding: 0;
+}
+
+@media print {
+  nav,
+  footer,
+  button:not(#cv-download-button),
+  .no-print {
+    display: none !important;
+  }
+
+  body {
+    background-color: white !important;
+    color: black !important;
+  }
+
+  @page {
+    size: A4 portrait;
+    margin: 1.5cm;
+  }
+
+  main {
+    padding: 0 !important;
+  }
+
+  /* Remove shadows and hover effects */
+  * {
+    box-shadow: none !important;
+    transition: none !important;
+  }
+
+  /* Adjust colors for printing */
+  .dark\:text-dark-text,
+  .dark\:text-dark-text-secondary,
+  .text-light-text,
+  .text-light-text-secondary {
+    color: #000 !important;
+  }
+
+  .dark\:bg-dark-surface,
+  .dark\:bg-dark-secondary,
+  .bg-light-surface,
+  .bg-light-secondary {
+    background-color: #fff !important;
+  }
+
+  /* Ensure all sections are visible */
+  .opacity-0 {
+    opacity: 1 !important;
+  }
+
+  /* Maintain the red accent for visual identity */
+  .border-brand-red {
+    border-color: #d83333 !important;
+  }
+
+  /* Ensure all text is visible */
+  .text-brand-red {
+    color: #d83333 !important;
+  }
+
+  /* Ensure backgrounds print correctly */
+  .bg-brand-red {
+    background-color: #d83333 !important;
+  }
+}

--- a/src/components/OgImage.jsx
+++ b/src/components/OgImage.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import styles from "../styles/OgImage.module.css";
 
 /**
  * OgImage component for generating dynamic Open Graph images
@@ -6,132 +7,37 @@ import React from 'react';
  * For now, the static image will be used, but this provides a template for future use
  */
 const OgImage = ({ name = "Oriol Macias", title = "Software Developer" }) => {
-    return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'column',
-                height: '100%',
-                width: '100%',
-                backgroundColor: '#121620',
-                backgroundImage: 'linear-gradient(to right bottom, #121620, #1e2433)',
-                padding: '60px',
-                fontFamily: 'Helvetica, Arial, sans-serif',
-                position: 'relative',
-            }}
-        >
-            {/* Red accent element - top left */}
-            <div
-                style={{
-                    position: 'absolute',
-                    top: '0',
-                    left: '0',
-                    width: '100px',
-                    height: '12px',
-                    backgroundColor: '#D83333',
-                }}
-            />
+  return (
+    <div className={styles.container}>
+      {/* Red accent element - top left */}
+      <div className={styles.topAccent} />
 
-            {/* Top header section */}
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'space-between',
-                    marginBottom: '40px',
-                }}
-            >
-                {/* Logo */}
-                <div
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        width: '50px',
-                        height: '50px',
-                        backgroundColor: '#D83333',
-                        color: 'white',
-                        fontSize: '20px',
-                        fontWeight: 'bold',
-                    }}
-                >
-                    OM
-                </div>
+      {/* Top header section */}
+      <div className={styles.header}>
+        {/* Logo */}
+        <div className={styles.logo}>OM</div>
 
-                {/* URLs */}
-                <div
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        color: '#9ca3af',
-                        fontSize: '16px',
-                    }}
-                >
-                    oriolmacias.dev | github.com/MaciWP
-                </div>
-            </div>
+        {/* URLs */}
+        <div className={styles.urls}>oriolmacias.dev | github.com/MaciWP</div>
+      </div>
 
-            {/* Main content */}
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    flexGrow: 1,
-                }}
-            >
-                <h1
-                    style={{
-                        fontSize: '64px',
-                        fontWeight: 'bold',
-                        color: 'white',
-                        margin: '0',
-                        lineHeight: '1.2',
-                    }}
-                >
-                    {name}
-                </h1>
+      {/* Main content */}
+      <div className={styles.content}>
+        <h1 className={styles.name}>{name}</h1>
 
-                <h2
-                    style={{
-                        fontSize: '36px',
-                        fontWeight: 'medium',
-                        color: '#D83333',
-                        margin: '0',
-                        marginTop: '16px',
-                    }}
-                >
-                    {title}
-                </h2>
+        <h2 className={styles.title}>{title}</h2>
 
-                <p
-                    style={{
-                        fontSize: '24px',
-                        color: '#9ca3af',
-                        marginTop: '32px',
-                        maxWidth: '650px',
-                        lineHeight: '1.4',
-                    }}
-                >
-                    Backend Developer specializing in industrial protocol integration with 8+ years
-                    delivering high-performance applications. Expertise in Python, C#, .NET, Django,
-                    and data center infrastructure.
-                </p>
-            </div>
+        <p className={styles.description}>
+          Backend Developer specializing in industrial protocol integration with
+          8+ years delivering high-performance applications. Expertise in
+          Python, C#, .NET, Django, and data center infrastructure.
+        </p>
+      </div>
 
-            {/* Red accent element - bottom right */}
-            <div
-                style={{
-                    position: 'absolute',
-                    bottom: '0',
-                    right: '0',
-                    width: '200px',
-                    height: '8px',
-                    backgroundColor: '#D83333',
-                }}
-            />
-        </div>
-    );
+      {/* Red accent element - bottom right */}
+      <div className={styles.bottomAccent} />
+    </div>
+  );
 };
 
 export default OgImage;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,14 +114,7 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
       client:load
     />
 
-    <style is:inline>
-      /* Estilos críticos para prevenir CLS */
-      #skills,
-      .nav-container,
-      .profile-image-container {
-        content-visibility: auto;
-      }
-    </style>
+    <link rel="stylesheet" href="/styles/layout-inline.css" />
 
     <!-- CSS de correcciones combinadas de accesibilidad y CLS -->
     <link rel="stylesheet" href="/styles/combined.css" />
@@ -204,74 +197,6 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
     <link rel="stylesheet" href="/styles/font-awesome-fallback.css" />
 
     <!-- Critical Font Awesome styles inlined for faster rendering -->
-    <style is:inline>
-      /* Core Font Awesome styles for immediate icon rendering */
-      @font-face {
-        font-family: "Font Awesome 5 Free";
-        font-style: normal;
-        font-weight: 900;
-        font-display: swap;
-        src: url("/styles/fonts/fa-solid-900.woff2") format("woff2");
-      }
-
-      @font-face {
-        font-family: "Font Awesome 5 Brands";
-        font-style: normal;
-        font-weight: 400;
-        font-display: swap;
-        src: url("/styles/fonts/fa-brands-400.woff2") format("woff2");
-      }
-
-      .fas,
-      .fa-solid {
-        font-family: "Font Awesome 5 Free";
-        font-weight: 900;
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        display: inline-block;
-        font-style: normal;
-        font-variant: normal;
-        text-rendering: auto;
-        line-height: 1;
-      }
-
-      .fab,
-      .fa-brands {
-        font-family: "Font Awesome 5 Brands";
-        font-weight: 400;
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        display: inline-block;
-        font-style: normal;
-        font-variant: normal;
-        text-rendering: auto;
-        line-height: 1;
-      }
-
-      /* Estilos críticos para el navbar sticky */
-      nav,
-      header nav,
-      nav[role="navigation"],
-      header[role="banner"] {
-        position: -webkit-sticky !important;
-        position: sticky !important;
-        top: 0 !important;
-        z-index: 50 !important;
-      }
-
-      /* Asegurar que el header no interfiera con el posicionamiento */
-      header[role="banner"] {
-        display: block;
-        position: static;
-        z-index: auto;
-      }
-
-      /* Sin márgenes o paddings que afecten al navbar */
-      header[role="banner"] {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
 
     <!-- Cargar el sistema unificado de internacionalización -->
     <script is:inline src="/scripts/i18n.js" onerror="window.i18nFailed = true;"
@@ -328,72 +253,6 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
       })();
     </script>
 
-    <!-- Print styles for PDF download capability -->
-    <style is:inline>
-      @media print {
-        nav,
-        footer,
-        button:not(#cv-download-button),
-        .no-print {
-          display: none !important;
-        }
-
-        body {
-          background-color: white !important;
-          color: black !important;
-        }
-
-        @page {
-          size: A4 portrait;
-          margin: 1.5cm;
-        }
-
-        main {
-          padding: 0 !important;
-        }
-
-        /* Remove shadows and hover effects */
-        * {
-          box-shadow: none !important;
-          transition: none !important;
-        }
-
-        /* Adjust colors for printing */
-        .dark\:text-dark-text,
-        .dark\:text-dark-text-secondary,
-        .text-light-text,
-        .text-light-text-secondary {
-          color: #000 !important;
-        }
-
-        .dark\:bg-dark-surface,
-        .dark\:bg-dark-secondary,
-        .bg-light-surface,
-        .bg-light-secondary {
-          background-color: #fff !important;
-        }
-
-        /* Ensure all sections are visible */
-        .opacity-0 {
-          opacity: 1 !important;
-        }
-
-        /* Maintain the red accent for visual identity */
-        .border-brand-red {
-          border-color: #d83333 !important;
-        }
-
-        /* Ensure all text is visible */
-        .text-brand-red {
-          color: #d83333 !important;
-        }
-
-        /* Ensure backgrounds print correctly */
-        .bg-brand-red {
-          background-color: #d83333 !important;
-        }
-      }
-    </style>
 
     <!-- Añadir al <head> de src/layouts/Layout.astro justo antes del cierre </head> -->
     <script is:inline>

--- a/src/styles/OgImage.module.css
+++ b/src/styles/OgImage.module.css
@@ -1,0 +1,86 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background-color: #121620;
+  background-image: linear-gradient(to right bottom, #121620, #1e2433);
+  padding: 60px;
+  font-family: Helvetica, Arial, sans-serif;
+  position: relative;
+}
+
+.topAccent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100px;
+  height: 12px;
+  background-color: #d83333;
+}
+
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 40px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  background-color: #d83333;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.urls {
+  display: flex;
+  align-items: center;
+  color: #9ca3af;
+  font-size: 16px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-grow: 1;
+}
+
+.name {
+  font-size: 64px;
+  font-weight: bold;
+  color: white;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.title {
+  font-size: 36px;
+  font-weight: 500;
+  color: #d83333;
+  margin: 0;
+  margin-top: 16px;
+}
+
+.description {
+  font-size: 24px;
+  color: #9ca3af;
+  margin-top: 32px;
+  max-width: 650px;
+  line-height: 1.4;
+}
+
+.bottomAccent {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 200px;
+  height: 8px;
+  background-color: #d83333;
+}

--- a/src/styles/layout-inline.css
+++ b/src/styles/layout-inline.css
@@ -1,0 +1,131 @@
+/* Styles extracted from Layout.astro */
+#skills,
+.nav-container,
+.profile-image-container {
+  content-visibility: auto;
+}
+
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: url("/styles/fonts/fa-solid-900.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "Font Awesome 5 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("/styles/fonts/fa-brands-400.woff2") format("woff2");
+}
+
+.fas,
+.fa-solid {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
+.fab,
+.fa-brands {
+  font-family: "Font Awesome 5 Brands";
+  font-weight: 400;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
+/* Sticky navbar adjustments */
+nav,
+header nav,
+nav[role="navigation"],
+header[role="banner"] {
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0 !important;
+  z-index: 50 !important;
+}
+
+header[role="banner"] {
+  display: block;
+  position: static;
+  z-index: auto;
+  margin: 0;
+  padding: 0;
+}
+
+@media print {
+  nav,
+  footer,
+  button:not(#cv-download-button),
+  .no-print {
+    display: none !important;
+  }
+
+  body {
+    background-color: white !important;
+    color: black !important;
+  }
+
+  @page {
+    size: A4 portrait;
+    margin: 1.5cm;
+  }
+
+  main {
+    padding: 0 !important;
+  }
+
+  /* Remove shadows and hover effects */
+  * {
+    box-shadow: none !important;
+    transition: none !important;
+  }
+
+  /* Adjust colors for printing */
+  .dark\:text-dark-text,
+  .dark\:text-dark-text-secondary,
+  .text-light-text,
+  .text-light-text-secondary {
+    color: #000 !important;
+  }
+
+  .dark\:bg-dark-surface,
+  .dark\:bg-dark-secondary,
+  .bg-light-surface,
+  .bg-light-secondary {
+    background-color: #fff !important;
+  }
+
+  /* Ensure all sections are visible */
+  .opacity-0 {
+    opacity: 1 !important;
+  }
+
+  /* Maintain the red accent for visual identity */
+  .border-brand-red {
+    border-color: #d83333 !important;
+  }
+
+  /* Ensure all text is visible */
+  .text-brand-red {
+    color: #d83333 !important;
+  }
+
+  /* Ensure backgrounds print correctly */
+  .bg-brand-red {
+    background-color: #d83333 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- move OgImage styles to a CSS module
- add layout-inline styles and link from layout
- provide minimal ESLint config

## Testing
- `npx prettier --write src/components/OgImage.jsx src/styles/OgImage.module.css src/styles/layout-inline.css eslint.config.js public/styles/OgImage.module.css public/styles/layout-inline.css`
- `npm run lint` *(fails: all files ignored due to missing plugins)*