### PR TITLE
Add social media data and footer links

### DIFF
--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,72 +1,92 @@
 {
-    "title": "Oriol Macias - Software Developer CV & Portfolio",
-    "description": "Professional CV and portfolio for Oriol Macias, a Software Developer specialized in backend development, industrial protocols integration, and data center infrastructure.",
-    "keywords": [
-        "Oriol Macias",
-        "Software Developer",
-        "Backend Developer",
-        "CV",
-        "Portfolio",
-        "Python",
-        "Django",
-        "C#",
-        ".NET",
-        "SNMP",
-        "MODBUS",
-        "BACnet",
-        "Data Center Infrastructure",
-        "API Development",
-        "Software Engineering",
-        "Protocol Integration"
-    ],
-    "author": "Oriol Macias",
-    "canonical": "https://oriolmacias.dev/",
-    "ogImage": "/images/oriol-macias-og.jpg",
-    "ogTitle": "Oriol Macias | Software Developer",
-    "ogDescription": "Backend Developer with 8+ years of experience in industrial protocol integration and high-performance applications.",
-    "twitterTitle": "Oriol Macias | Software Developer CV",
-    "twitterDescription": "Specialized in backend development, industrial protocols integration, and data center infrastructure.",
-    "languages": [
-        {
-            "code": "en",
-            "name": "English",
-            "url": "https://oriolmacias.dev/"
-        },
-        {
-            "code": "es",
-            "name": "Español",
-            "url": "https://oriolmacias.dev/es/"
-        },
-        {
-            "code": "fr",
-            "name": "Français",
-            "url": "https://oriolmacias.dev/fr/"
-        }
-    ],
-    "socialMedia": [
-        {
-            "platform": "LinkedIn",
-            "url": "https://linkedin.com/in/oriolmaciasbadosa",
-            "icon": "fab fa-linkedin"
-        },
-        {
-            "platform": "GitHub",
-            "url": "https://github.com/MaciWP",
-            "icon": "fab fa-github"
-        }
-    ],
-    "schema": {
-        "name": "Oriol Macias",
-        "jobTitle": "Software Developer",
-        "image": "https://oriolmacias.dev/images/oriol_macias.jpg",
-        "url": "https://oriolmacias.dev",
-        "sameAs": [
-            "https://linkedin.com/in/oriolmaciasbadosa",
-            "https://github.com/MaciWP"
-        ],
-        "worksFor": {
-            "name": "Bjumper",
-            "url": "https://bjumper.com"
-        }
+  "title": "Oriol Macias - Software Developer CV & Portfolio",
+  "description": "Professional CV and portfolio for Oriol Macias, a Software Developer specialized in backend development, industrial protocols integration, and data center infrastructure.",
+  "keywords": [
+    "Oriol Macias",
+    "Software Developer",
+    "Backend Developer",
+    "CV",
+    "Portfolio",
+    "Python",
+    "Django",
+    "C#",
+    ".NET",
+    "SNMP",
+    "MODBUS",
+    "BACnet",
+    "Data Center Infrastructure",
+    "API Development",
+    "Software Engineering",
+    "Protocol Integration"
+  ],
+  "author": "Oriol Macias",
+  "canonical": "https://oriolmacias.dev/",
+  "ogImage": "/images/oriol-macias-og.jpg",
+  "ogTitle": "Oriol Macias | Software Developer",
+  "ogDescription": "Backend Developer with 8+ years of experience in industrial protocol integration and high-performance applications.",
+  "twitterTitle": "Oriol Macias | Software Developer CV",
+  "twitterDescription": "Specialized in backend development, industrial protocols integration, and data center infrastructure.",
+  "languages": [
+    {
+      "code": "en",
+      "name": "English",
+      "url": "https://oriolmacias.dev/"
+    },
+    {
+      "code": "es",
+      "name": "Español",
+      "url": "https://oriolmacias.dev/es/"
+    },
+    {
+      "code": "fr",
+      "name": "Français",
+      "url": "https://oriolmacias.dev/fr/"
     }
+  ],
+  "socialMedia": [
+    {
+      "platform": "LinkedIn",
+      "url": "https://linkedin.com/in/oriolmaciasbadosa",
+      "icon": "fab fa-linkedin"
+    },
+    {
+      "platform": "GitHub",
+      "url": "https://github.com/MaciWP",
+      "icon": "fab fa-github"
+    },
+    {
+      "platform": "Facebook",
+      "url": "https://facebook.com/oriolmacias",
+      "icon": "fab fa-facebook"
+    },
+    {
+      "platform": "Twitter",
+      "url": "https://twitter.com/oriolmacias",
+      "icon": "fab fa-twitter"
+    },
+    {
+      "platform": "Instagram",
+      "url": "https://instagram.com/oriolmacias",
+      "icon": "fab fa-instagram"
+    },
+    {
+      "platform": "YouTube",
+      "url": "https://youtube.com/@oriolmacias",
+      "icon": "fab fa-youtube"
+    }
+  ],
+  "schema": {
+    "name": "Oriol Macias",
+    "jobTitle": "Software Developer",
+    "image": "https://oriolmacias.dev/images/oriol_macias.jpg",
+    "url": "https://oriolmacias.dev",
+    "sameAs": [
+      "https://linkedin.com/in/oriolmaciasbadosa",
+      "https://github.com/MaciWP"
+    ],
+    "worksFor": {
+      "name": "Bjumper",
+      "url": "https://bjumper.com"
+    }
+  }
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 import SkipToContent from "../components/SkipToContent";
 import A11yAnnouncer from "../components/A11yAnnouncer";
 import LanguageAlternates from "../components/LanguageAlternates";
+import meta from "../data/meta.json";
 
 // Define props interface
 export interface Props {
@@ -35,6 +36,8 @@ const {
 const fullCanonicalUrl = canonicalUrl.startsWith("http")
   ? canonicalUrl
   : new URL(Astro.url.pathname, "https://oriolmacias.dev").href;
+
+const socialMedia = meta.socialMedia || [];
 ---
 
 <!doctype html>
@@ -106,6 +109,9 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
     <meta name="description" content={description} />
     <meta name="author" content="Oriol Macias" />
     <link rel="canonical" href={fullCanonicalUrl} />
+    {socialMedia.map((sm) => (
+      <link rel="me" href={sm.url} />
+    ))}
 
     <!-- Enlaces hreflang corregidos -->
     <LanguageAlternates
@@ -533,24 +539,25 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
                   </p>
                 </div>
                 <div class="flex items-center gap-6">
+                  {socialMedia.map((sm) => (
+                    <a
+                      href={sm.url}
+                      target="_blank"
+                      rel="me noopener noreferrer"
+                      class="text-lg text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red dark:hover:text-brand-red transition-colors"
+                      aria-label={`${sm.platform} Profile`}
+                    >
+                      <i class={sm.icon} aria-hidden="true"></i>
+                      <span class="sr-only">{sm.platform}</span>
+                    </a>
+                  ))}
                   <a
                     href="#top"
                     class="text-sm flex items-center text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red dark:hover:text-brand-red transition-colors"
-                    aria-label={lang === "es"
-                      ? "Volver al inicio de la página"
-                      : lang === "fr"
-                        ? "Retourner en haut de la page"
-                        : "Return to top of page"}
+                    aria-label={lang === "es" ? "Volver al inicio de la página" : lang === "fr" ? "Retourner en haut de la page" : "Return to top of page"}
                   >
-                    <i class="fas fa-arrow-up mr-2 text-xs" aria-hidden="true"
-                    ></i>
-                    {
-                      lang === "es"
-                        ? "Volver arriba"
-                        : lang === "fr"
-                          ? "Retour en haut"
-                          : "Back to top"
-                    }
+                    <i class="fas fa-arrow-up mr-2 text-xs" aria-hidden="true"></i>
+                    {lang === "es" ? "Volver arriba" : lang === "fr" ? "Retour en haut" : "Back to top"}
                   </a>
                 </div>
                 <button


### PR DESCRIPTION
## Summary
- expand `socialMedia` metadata with Facebook, Twitter, Instagram and YouTube
- import metadata in `Layout.astro` and expose a `socialMedia` variable
- add `<link rel="me">` elements in the page head
- render social icons in the footer using metadata

## Testing
- `npx prettier --check src/data/meta.json src/layouts/Layout.astro` *(fails to parse `.astro` file)*
- `npm run lint` *(fails: ESLint couldn't find config)*