### PR TITLE
Add GA4 analytics tracking

### DIFF
--- a/public/scripts/ga-events.js
+++ b/public/scripts/ga-events.js
@@ -1,0 +1,29 @@
+(function () {
+  function trackScroll() {
+    const scrolledRatio =
+      (window.scrollY + window.innerHeight) /
+      document.documentElement.scrollHeight;
+    if (scrolledRatio > 0.5) {
+      window.removeEventListener("scroll", trackScroll);
+      if (window.gtag) {
+        window.gtag("event", "scroll_halfway");
+      }
+    }
+  }
+
+  window.addEventListener("scroll", trackScroll, { passive: true });
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("#cv-download-button, .cta").forEach((el) => {
+      el.addEventListener("click", () => {
+        const label = el.id || el.textContent?.trim() || "cta";
+        if (window.gtag) {
+          window.gtag("event", "cta_click", {
+            event_category: "engagement",
+            event_label: label,
+          });
+        }
+      });
+    });
+  });
+})();

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly PUBLIC_GA_MEASUREMENT_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,6 +40,19 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
 <!doctype html>
 <html lang={lang} class="dark" dir="ltr">
   <head>
+    <script
+      async
+      src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA_MEASUREMENT_ID}`}
+    ></script>
+    <script is:inline define:vars={{ GA_ID: import.meta.env.PUBLIC_GA_MEASUREMENT_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', GA_ID);
+    </script>
+    <script src="/scripts/ga-events.js" defer></script>
     <link
       rel="preload"
       as="image"


### PR DESCRIPTION
## Summary
- embed GA4 snippet in `Layout.astro`
- add script with scroll and CTA analytics
- make GA ID configurable via environment variable

## Testing
- `npx prettier --check public/scripts/ga-events.js src/env.d.ts`
- `npm run lint` *(fails: ESLint couldn't find config)*