### PR TITLE
Add StructuredData to layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,8 @@ import ErrorBoundary from "../components/ErrorBoundary";
 import SkipToContent from "../components/SkipToContent";
 import A11yAnnouncer from "../components/A11yAnnouncer";
 import LanguageAlternates from "../components/LanguageAlternates";
+import StructuredData from "../components/StructuredData";
+import headerData from "../data/header";
 
 // Define props interface
 export interface Props {
@@ -481,6 +483,10 @@ const fullCanonicalUrl = canonicalUrl.startsWith("http")
     <link rel="stylesheet" href="/styles/font-awesome-optimized.css" />
 
     <script is:inline src="/scripts/react-error-recovery.js"></script>
+    <StructuredData
+      name={headerData.fullName}
+      jobTitle={headerData.jobTitle}
+    />
   </head>
   <body
     class="min-h-screen bg-light-primary dark:bg-dark-primary text-light-text dark:text-dark-text font-sans body-transition"


### PR DESCRIPTION
## Summary
- import StructuredData in `Layout.astro`
- render `<StructuredData />` before closing `</head>`

## Testing
- `npx prettier --check src/layouts/Layout.astro` *(fails: No parser could be inferred)*
- `npm run lint` *(fails: ESLint couldn't find a config)*