### PR TITLE
Shorten meta descriptions

### DIFF
--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -14,7 +14,7 @@ import Projects from "../../components/cv/Projects";
 // Enhanced metadata for SEO (Spanish version)
 const pageTitle = "Oriol Macias - Portfolio de Desarrollador de Software";
 const pageDescription =
-    "CV y portfolio profesional de Oriol Macias, Desarrollador Backend con más de 8 años de experiencia en integración de protocolos industriales (SNMP, MODBUS, BACnet) e infraestructura de centros de datos.";
+    "CV y portfolio de Oriol Macias, Desarrollador Backend con más de 8 años integrando protocolos industriales y mejorando infraestructura de centros de datos.";
 const ogImage = "/images/oriol_macias.jpg";
 const canonicalUrl = "https://oriolmacias.dev/es/";
 

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -14,7 +14,7 @@ import Projects from "../../components/cv/Projects";
 // Enhanced metadata for SEO (French version)
 const pageTitle = "Oriol Macias - Portfolio de Développeur Logiciel";
 const pageDescription =
-    "CV et portfolio professionnel d'Oriol Macias, Développeur Backend avec plus de 8 ans d'expérience en intégration de protocoles industriels (SNMP, MODBUS, BACnet) et infrastructure de centres de données.";
+    "CV et portfolio d'Oriol Macias, Développeur Backend avec 8+ ans d'expérience intégrant des protocoles industriels et optimisant des centres de données.";
 const ogImage = "/images/oriol_macias.jpg";
 const canonicalUrl = "https://oriolmacias.dev/fr/";
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ import Projects from "../components/cv/Projects";
 // Enhanced metadata for SEO
 const pageTitle = "Oriol Macias - Software Developer CV & Portfolio";
 const pageDescription =
-  "Professional CV and portfolio for Oriol Macias, a Backend Developer with 8+ years of experience in industrial protocol integration (SNMP, MODBUS, BACnet) and data center infrastructure.";
+  "CV and portfolio for Oriol Macias, Backend Developer with 8+ years integrating industrial protocols and optimizing data center infrastructure.";
 const ogImage = "/images/oriol_macias.jpg";
 const canonicalUrl = "https://oriolmacias.dev/";
 


### PR DESCRIPTION
## Summary
- trim `pageDescription` in EN, ES, and FR index pages

## Testing
- `npx prettier --write src/pages/index.astro src/pages/es/index.astro src/pages/fr/index.astro` *(fails: No parser could be inferred)*
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: couldn't find eslint-plugin-react)*