### PR TITLE
Separate job title from name in ProfileHeader

### DIFF
--- a/src/components/cv/ProfileHeader.jsx
+++ b/src/components/cv/ProfileHeader.jsx
@@ -158,8 +158,14 @@ const ProfileHeader = () => {
           <div className="md:col-span-8 space-y-6">
             <div>
               <h1 className="text-4xl md:text-5xl font-bold mb-2">
-                {headerData.fullName} – {localData.jobTitle}
+                {headerData.fullName}
               </h1>
+              <h2
+                className="text-xl md:text-2xl text-brand-red dark:text-brand-red font-medium"
+                data-i18n="header.jobTitle"
+              >
+                {localData.jobTitle}
+              </h2>
             </div>
 
             <p


### PR DESCRIPTION
## Summary
- split job title into its own heading in `ProfileHeader`

## Testing
- `npx prettier --write src/components/cv/ProfileHeader.jsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*