### PR TITLE
Add CDN preconnect

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -84,6 +84,9 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
       fetchpriority="high"
     />
 
+    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+
     <link
       rel="preload"
       as="font"


### PR DESCRIPTION
## Summary
- preconnect and dns-prefetch for cdnjs before Font Awesome assets load

## Testing
- `npx prettier --check .`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*