### PR TITLE
Improve hero image preload

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,11 +68,23 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
       /images/oriol_macias-md.avif 800w,
       /images/oriol_macias-lg.avif 1200w
     "
+      type="image/avif"
     />
     <link
       rel="preload"
       as="image"
-      href="/images/oriol_macias-640.avif"
+      href="/images/oriol_macias-sm.webp"
+      imagesrcset="
+      /images/oriol_macias-sm.webp 400w,
+      /images/oriol_macias-md.webp 800w,
+      /images/oriol_macias-lg.webp 1200w
+    "
+      type="image/webp"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="/images/oriol_macias-1280.avif"
       imagesrcset="
       /images/oriol_macias-192.avif 192w,
       /images/oriol_macias-320.avif 320w,
@@ -82,6 +94,22 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
     "
       imagesizes="(max-width: 767px) 100vw, 400px"
       fetchpriority="high"
+      type="image/avif"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="/images/oriol_macias-1280.webp"
+      imagesrcset="
+      /images/oriol_macias-192.webp 192w,
+      /images/oriol_macias-320.webp 320w,
+      /images/oriol_macias-640.webp 640w,
+      /images/oriol_macias-960.webp 960w,
+      /images/oriol_macias-1280.webp 1280w
+    "
+      imagesizes="(max-width: 767px) 100vw, 400px"
+      fetchpriority="high"
+      type="image/webp"
     />
 
     <link


### PR DESCRIPTION
## Summary
- preload AVIF and WebP variants for hero image
- use the largest resolution and high fetch priority

## Testing
- `npx prettier --check src/layouts/Layout.astro`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx lighthouse --help` *(fails: EHOSTUNREACH)*