### PR TITLE
Wrap GA scripts with conditional

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,18 +46,22 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
 <!doctype html>
 <html lang={lang} class="dark" dir="ltr">
   <head>
-    <script
-      async
-      src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA_MEASUREMENT_ID}`}
-    ></script>
-    <script is:inline define:vars={{ GA_ID: import.meta.env.PUBLIC_GA_MEASUREMENT_ID }}>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', GA_ID);
-    </script>
+    {import.meta.env.PUBLIC_GA_MEASUREMENT_ID && (
+      <>
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA_MEASUREMENT_ID}`}
+        ></script>
+        <script is:inline define:vars={{ GA_ID: import.meta.env.PUBLIC_GA_MEASUREMENT_ID }}>
+          window.dataLayer = window.dataLayer || [];
+          function gtag() {
+            dataLayer.push(arguments);
+          }
+          gtag('js', new Date());
+          gtag('config', GA_ID);
+        </script>
+      </>
+    )}
     <script src="/scripts/ga-events.js" defer></script>
     <link
       rel="preload"


### PR DESCRIPTION
## Summary
- conditionally include GA `<script>` tags only when `PUBLIC_GA_MEASUREMENT_ID` is set in `Layout.astro`

## Testing
- `npx prettier --write src/layouts/Layout.astro` *(fails: No parser could be inferred for .astro)*
- `npx prettier --write .`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*