### PR TITLE
Remove inline X-Frame-Options headers

### DIFF
--- a/src/components/SecurityHeaders.astro
+++ b/src/components/SecurityHeaders.astro
@@ -11,7 +11,6 @@
 />
 
 <!-- Additional Security Headers -->
-<meta http-equiv="X-Frame-Options" content="DENY" />
 <meta http-equiv="X-Content-Type-Options" content="nosniff" />
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
 <meta

--- a/src/components/SecurityHeaders.jsx
+++ b/src/components/SecurityHeaders.jsx
@@ -86,8 +86,6 @@ const SecurityHeaders = () => {
             {/* HSTS Header */}
             <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload" />
 
-            {/* X-Frame-Options prevents your site from being embedded in iframes on other sites */}
-            <meta http-equiv="X-Frame-Options" content="DENY" />
 
             {/* X-Content-Type-Options prevents MIME type sniffing */}
             <meta http-equiv="X-Content-Type-Options" content="nosniff" />


### PR DESCRIPTION
## Summary
- drop `X-Frame-Options` meta tag from SecurityHeaders components
- rely on Netlify header in `netlify.toml`

## Testing
- `npx prettier --write src/components/SecurityHeaders.jsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*