### PR TITLE
Fix duplicate ids for CV download buttons

### DIFF
--- a/public/scripts/ga-events.js
+++ b/public/scripts/ga-events.js
@@ -15,7 +15,9 @@
 
   document.addEventListener("DOMContentLoaded", () => {
     document
-      .querySelectorAll("#cv-download-button, #pdf-download-button, .cta")
+      .querySelectorAll(
+        "#cv-download-button, #pdf-download-button, #cv-print-button, .cta",
+      )
       .forEach((el) => {
         el.addEventListener("click", () => {
           const label = el.id || el.textContent?.trim() || "cta";

--- a/public/styles/a11y-improvements.css
+++ b/public/styles/a11y-improvements.css
@@ -46,13 +46,13 @@ h4.text-brand-red {
 }
 
 /* Fix "Download CV" button contrast in the footer */
-#pdf-download-button {
+#cv-print-button {
   color: #ffffff !important;
   background-color: var(--accessible-brand-red) !important;
   border-color: var(--accessible-brand-red) !important;
 }
 
-#pdf-download-button:hover {
+#cv-print-button:hover {
   background-color: #a81c1c !important;
 }
 

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -291,7 +291,7 @@ html.theme-transitioning * {
   /* Ocultar elementos no necesarios para impresión */
   nav,
   footer,
-  button:not(#pdf-download-button),
+  button:not(#cv-print-button),
   .no-print {
     display: none !important;
   }

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -297,7 +297,7 @@ html.theme-transitioning * {
   /* Ocultar elementos no necesarios para impresión */
   nav,
   footer,
-  button:not(#pdf-download-button),
+  button:not(#cv-print-button),
   .no-print {
     display: none !important;
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -388,7 +388,7 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
       @media print {
         nav,
         footer,
-        button:not(#pdf-download-button),
+        button:not(#cv-print-button),
         .no-print {
           display: none !important;
         }
@@ -618,7 +618,7 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
                   </a>
                 </div>
                 <button
-                  id="pdf-download-button"
+                  id="cv-print-button"
                   class="text-xs h-8 flex items-center px-3 py-1 border border-brand-red text-brand-red dark:text-brand-red hover:bg-brand-red hover:text-white dark:hover:bg-brand-red dark:hover:text-white transition-colors duration-300"
                   onclick="window.print()"
                   aria-label={lang === "es"
@@ -747,6 +747,9 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
           fbq('init', pixelId);
           fbq('track', 'PageView');
           document.getElementById('pdf-download-button')?.addEventListener('click', () => {
+            fbq('track', 'Lead');
+          });
+          document.getElementById('cv-print-button')?.addEventListener('click', () => {
             fbq('track', 'Lead');
           });
         }

--- a/src/styles/a11y-improvements.css
+++ b/src/styles/a11y-improvements.css
@@ -46,13 +46,13 @@ h4.text-brand-red {
 }
 
 /* Fix "Download CV" button contrast in the footer */
-#pdf-download-button {
+#cv-print-button {
   color: #ffffff !important;
   background-color: var(--accessible-brand-red) !important;
   border-color: var(--accessible-brand-red) !important;
 }
 
-#pdf-download-button:hover {
+#cv-print-button:hover {
   background-color: #a81c1c !important;
 }
 

--- a/src/styles/combined.css
+++ b/src/styles/combined.css
@@ -49,13 +49,13 @@ h4.text-brand-red {
 }
 
 /* Fix "Download CV" button contrast in the footer */
-#pdf-download-button {
+#cv-print-button {
   color: #ffffff !important;
   background-color: var(--accessible-brand-red) !important;
   border-color: var(--accessible-brand-red) !important;
 }
 
-#pdf-download-button:hover {
+#cv-print-button:hover {
   background-color: #a81c1c !important;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,7 +296,7 @@ html.theme-transitioning * {
   /* Ocultar elementos no necesarios para impresión */
   nav,
   footer,
-  button:not(#pdf-download-button),
+  button:not(#cv-print-button),
   .no-print {
     display: none !important;
   }


### PR DESCRIPTION
## Summary
- avoid duplicate `pdf-download-button` id by renaming the footer print button
- update CSS styles and analytics script to use new `cv-print-button` id

## Testing
- `npx prettier --check src/styles/global.css src/styles/a11y-improvements.css src/styles/combined.css public/styles/global.css public/styles/a11y-improvements.css public/styles/main.css public/scripts/ga-events.js`
- `npx prettier --check src/layouts/Layout.astro` *(fails: No parser could be inferred)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*