### PR TITLE
Add missing ESLint config package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "sharp": "^0.33.5"
       },
       "devDependencies": {
+        "@eslint/js": "^8.57.1",
         "eslint": "^8.57.1",
         "eslint-plugin-astro": "^0.31.4",
         "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "sharp": "^0.33.5"
   },
   "devDependencies": {
+    "@eslint/js": "^8.57.1",
     "eslint": "^8.57.1",
     "eslint-plugin-astro": "^0.31.4",
     "eslint-plugin-jsx-a11y": "^6.10.2",


### PR DESCRIPTION
## Summary
- include `@eslint/js` to satisfy ESLint config
- sync lockfile with the new dependency

## Testing
- `npx prettier --check package.json package-lock.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*