### PR TITLE
Fix I18nLoader hydration

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -549,7 +549,7 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
       <SkipToContent client:load />
       <A11yAnnouncer client:load />
 
-      <I18nLoader client:only>
+      <I18nLoader client:only="react">
         <!-- Navbar with ErrorBoundary -->
         <header role="banner">
           <ErrorBoundary>


### PR DESCRIPTION
## Summary
- specify `client:only="react"` for I18nLoader in Layout.astro

## Testing
- `npx prettier --check src/layouts/Layout.astro --ignore-unknown`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`
- `npm run preview`