### PR TITLE
Remove X-Frame-Options meta tags

### DIFF
--- a/src/components/SecurityHeaders.astro
+++ b/src/components/SecurityHeaders.astro
@@ -11,7 +11,6 @@
 />
 
 <!-- Additional Security Headers -->
-<meta http-equiv="X-Frame-Options" content="DENY" />
 <meta http-equiv="X-Content-Type-Options" content="nosniff" />
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
 <meta

--- a/src/components/SecurityHeaders.jsx
+++ b/src/components/SecurityHeaders.jsx
@@ -86,8 +86,6 @@ const SecurityHeaders = () => {
             {/* HSTS Header */}
             <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload" />
 
-            {/* X-Frame-Options prevents your site from being embedded in iframes on other sites */}
-            <meta http-equiv="X-Frame-Options" content="DENY" />
 
             {/* X-Content-Type-Options prevents MIME type sniffing */}
             <meta http-equiv="X-Content-Type-Options" content="nosniff" />


### PR DESCRIPTION
## Summary
- drop `<meta http-equiv="X-Frame-Options">` from SecurityHeaders components
- headers remain in `.htaccess` and `netlify.toml`

## Testing
- `npx prettier --write src/components/SecurityHeaders.jsx`
- `npx prettier --write src/components/SecurityHeaders.astro` *(fails: No parser could be inferred)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*