### PR TITLE
Add missing Netlify function directory

### DIFF
--- a/netlify/functions/empty-response.js
+++ b/netlify/functions/empty-response.js
@@ -1,0 +1,4 @@
+exports.handler = async () => ({
+  statusCode: 204,
+  body: "",
+});


### PR DESCRIPTION
## Summary
- add `netlify/functions/empty-response.js` so the path referenced from `netlify.toml` exists

## Testing
- `npx prettier --write .`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*