### PR TITLE
Add google site verification meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ pnpm install
 pnpm run dev
 ```
 
+### Environment Variables
+
+Set `PUBLIC_GOOGLE_SITE_VERIFICATION` in your `.env` or CI environment with the
+value provided by Google. It will be injected into the `<meta name="google-site-verification">` tag.
+
+```bash
+PUBLIC_GOOGLE_SITE_VERIFICATION=your_verification_token
+```
+
 ### Build
 
 ```bash

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
   readonly PUBLIC_GA_MEASUREMENT_ID: string;
+  readonly PUBLIC_GOOGLE_SITE_VERIFICATION: string;
 }
 
 interface ImportMeta {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -160,6 +160,12 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
     <meta name="description" content={description} />
     <meta name="author" content="Oriol Macias" />
     <link rel="canonical" href={fullCanonicalUrl} />
+    {import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION && (
+      <meta
+        name="google-site-verification"
+        content={import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION}
+      />
+    )}
     <SecurityHeaders />
 
     <!-- Enlaces hreflang corregidos -->


### PR DESCRIPTION
## Summary
- add optional `PUBLIC_GOOGLE_SITE_VERIFICATION` meta tag in layout
- expose the new env var in `src/env.d.ts`
- document usage of the env var in README

## Testing
- `npx prettier --write README.md src/env.d.ts` *(fails for .astro files: No parser could be inferred)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
