### PR TITLE
Fix build config and font download

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -106,7 +106,5 @@ export default defineConfig({
       sourcemap: true,
     },
   },
-  experimental: {
-    viewTransitions: true,
-  },
+  viewTransitions: true,
 });

--- a/netlify/functions/empty-response.js
+++ b/netlify/functions/empty-response.js
@@ -1,4 +1,3 @@
-exports.handler = async () => ({
-  statusCode: 204,
-  body: "",
-});
+export async function handler() {
+  return { statusCode: 204, body: "" };
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "analyze": "astro build --analyze",
     "styles": "node scripts/styles.js",
     "styles:optimize": "node scripts/styles.js --optimize",
-    "setup:font-awesome": "node /public/scripts/font-awesome.js",
+    "setup:font-awesome": "node scripts/font-awesome-setup.js",
     "check": "npm run check:contrast && npm run check:translations",
     "check:contrast": "node scripts/check-contrast.js",
     "check:translations": "node scripts/check-translations.js",

--- a/scripts/font-awesome-setup.js
+++ b/scripts/font-awesome-setup.js
@@ -444,7 +444,7 @@ async function setupFontAwesome() {
     for (const font of FONT_FILES) {
       const fontPath = path.join(PUBLIC_FONTS_DIR, font.name);
       console.log(`Descargando ${font.name}`);
-      // await downloadFile(font.url, fontPath);
+      await downloadFile(font.url, fontPath);
       console.log(`✓ Descargado ${font.name}`);
 
       // Configurar permisos apropiados


### PR DESCRIPTION
## Summary
- enable downloading Font Awesome fonts
- update Astro config to new `viewTransitions` option
- convert Netlify function to ESM
- correct path for `setup:font-awesome` script

## Testing
- `npx prettier --write scripts/font-awesome-setup.js astro.config.mjs netlify/functions/empty-response.js package.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*