### PR TITLE
Add blog posts and link from navigation

### DIFF
--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -5,84 +5,93 @@
 
 // Base navigation items with translations
 export const navItems = [
-    {
-        id: 'about',
-        name: {
-            en: 'About',
-            es: 'Sobre Mí',
-            fr: 'À Propos'
-        },
-        href: '#about'
+  {
+    id: "about",
+    name: {
+      en: "About",
+      es: "Sobre Mí",
+      fr: "À Propos",
     },
-    {
-        id: 'experience',
-        name: {
-            en: 'Experience',
-            es: 'Experiencia',
-            fr: 'Expérience'
-        },
-        href: '#experience'
+    href: "#about",
+  },
+  {
+    id: "experience",
+    name: {
+      en: "Experience",
+      es: "Experiencia",
+      fr: "Expérience",
     },
-    {
-        id: 'skills',
-        name: {
-            en: 'Skills',
-            es: 'Habilidades',
-            fr: 'Compétences'
-        },
-        href: '#skills'
+    href: "#experience",
+  },
+  {
+    id: "skills",
+    name: {
+      en: "Skills",
+      es: "Habilidades",
+      fr: "Compétences",
     },
-    {
-        id: 'education',
-        name: {
-            en: 'Education',
-            es: 'Educación',
-            fr: 'Formation'
-        },
-        href: '#education'
+    href: "#skills",
+  },
+  {
+    id: "education",
+    name: {
+      en: "Education",
+      es: "Educación",
+      fr: "Formation",
     },
-    {
-        id: 'languages',
-        name: {
-            en: 'Languages',
-            es: 'Idiomas',
-            fr: 'Langues'
-        },
-        href: '#languages'
+    href: "#education",
+  },
+  {
+    id: "languages",
+    name: {
+      en: "Languages",
+      es: "Idiomas",
+      fr: "Langues",
     },
-    {
-        id: 'projects',
-        name: {
-            en: 'Projects',
-            es: 'Proyectos',
-            fr: 'Projets'
-        },
-        href: '#projects'
-    }
+    href: "#languages",
+  },
+  {
+    id: "projects",
+    name: {
+      en: "Projects",
+      es: "Proyectos",
+      fr: "Projets",
+    },
+    href: "#projects",
+  },
+  {
+    id: "blog",
+    name: {
+      en: "Blog",
+      es: "Blog",
+      fr: "Blog",
+    },
+    href: "/blog/",
+  },
 ];
 
 // UI translations
 export const uiTranslations = {
-    downloadCV: {
-        en: 'Download CV',
-        es: 'Descargar CV',
-        fr: 'Télécharger CV'
-    },
-    backToTop: {
-        en: 'Back to top',
-        es: 'Volver arriba',
-        fr: 'Retour en haut'
-    },
-    openMenu: {
-        en: 'Open menu',
-        es: 'Abrir menú',
-        fr: 'Ouvrir le menu'
-    },
-    closeMenu: {
-        en: 'Close menu',
-        es: 'Cerrar menú',
-        fr: 'Fermer le menu'
-    }
+  downloadCV: {
+    en: "Download CV",
+    es: "Descargar CV",
+    fr: "Télécharger CV",
+  },
+  backToTop: {
+    en: "Back to top",
+    es: "Volver arriba",
+    fr: "Retour en haut",
+  },
+  openMenu: {
+    en: "Open menu",
+    es: "Abrir menú",
+    fr: "Ouvrir le menu",
+  },
+  closeMenu: {
+    en: "Close menu",
+    es: "Cerrar menú",
+    fr: "Fermer le menu",
+  },
 };
 
 /**
@@ -90,16 +99,16 @@ export const uiTranslations = {
  * @param {string} lang - Language code (en, es, fr)
  * @returns {Array} Navigation items with names in the specified language
  */
-export const getNavItems = (lang = 'en') => {
-    // Default to English if language not supported
-    const language = ['en', 'es', 'fr'].includes(lang) ? lang : 'en';
+export const getNavItems = (lang = "en") => {
+  // Default to English if language not supported
+  const language = ["en", "es", "fr"].includes(lang) ? lang : "en";
 
-    // Transform data structure to use the specified language
-    return navItems.map(item => ({
-        id: item.id,
-        name: item.name[language] || item.name.en, // Fallback to English
-        href: item.href
-    }));
+  // Transform data structure to use the specified language
+  return navItems.map((item) => ({
+    id: item.id,
+    name: item.name[language] || item.name.en, // Fallback to English
+    href: item.href,
+  }));
 };
 
 /**
@@ -108,16 +117,16 @@ export const getNavItems = (lang = 'en') => {
  * @param {string} lang - Language code (en, es, fr)
  * @returns {string} Translation in the specified language
  */
-export const getUITranslation = (key, lang = 'en') => {
-    // Default to English if language not supported
-    const language = ['en', 'es', 'fr'].includes(lang) ? lang : 'en';
+export const getUITranslation = (key, lang = "en") => {
+  // Default to English if language not supported
+  const language = ["en", "es", "fr"].includes(lang) ? lang : "en";
 
-    if (uiTranslations[key] && uiTranslations[key][language]) {
-        return uiTranslations[key][language];
-    }
+  if (uiTranslations[key] && uiTranslations[key][language]) {
+    return uiTranslations[key][language];
+  }
 
-    // Fallback to English or key itself
-    return uiTranslations[key]?.en || key;
+  // Fallback to English or key itself
+  return uiTranslations[key]?.en || key;
 };
 
 /**
@@ -125,9 +134,10 @@ export const getUITranslation = (key, lang = 'en') => {
  * @returns {Array} Navigation items with names in the current UI language
  */
 export const getCurrentLanguageNavItems = () => {
-    // Get current language from window object if available
-    const currentLang = (typeof window !== 'undefined' && window.CURRENT_LANGUAGE) || 'en';
-    return getNavItems(currentLang);
+  // Get current language from window object if available
+  const currentLang =
+    (typeof window !== "undefined" && window.CURRENT_LANGUAGE) || "en";
+  return getNavItems(currentLang);
 };
 
 /**
@@ -136,14 +146,15 @@ export const getCurrentLanguageNavItems = () => {
  * @returns {string} Translation in the current UI language
  */
 export const getCurrentUITranslation = (key) => {
-    // Get current language from window object if available
-    const currentLang = (typeof window !== 'undefined' && window.CURRENT_LANGUAGE) || 'en';
-    return getUITranslation(key, currentLang);
+  // Get current language from window object if available
+  const currentLang =
+    (typeof window !== "undefined" && window.CURRENT_LANGUAGE) || "en";
+  return getUITranslation(key, currentLang);
 };
 
 // For compatibility with existing code - English nav items
-export default navItems.map(item => ({
-    id: item.id,
-    name: item.name.en,
-    href: item.href
+export default navItems.map((item) => ({
+  id: item.id,
+  name: item.name.en,
+  href: item.href,
 }));

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -604,6 +604,12 @@ const pixelId = import.meta.env.PUBLIC_PIXEL_ID;
                 </p>
                 <div class="flex items-center gap-6">
                   <a
+                    href="/blog/"
+                    class="text-sm text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red dark:hover:text-brand-red transition-colors"
+                  >
+                    Blog
+                  </a>
+                  <a
                     href="#top"
                     class="text-sm flex items-center text-light-text-secondary dark:text-dark-text-secondary hover:text-brand-red dark:hover:text-brand-red transition-colors"
                     aria-label={lang === "es"

--- a/src/pages/blog/ai-driven-web.astro
+++ b/src/pages/blog/ai-driven-web.astro
@@ -1,0 +1,54 @@
+---
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="AI Driven Web Experiences" description="Exploring how artificial intelligence is shaping modern web development">
+  <main class="prose lg:prose-lg mx-auto px-4 py-8">
+    <h1>AI Driven Web Experiences</h1>
+    <p>
+      Artificial intelligence is no longer a distant promise but a practical tool that influences how we build and interact with websites. From recommendation engines to automated accessibility checks, AI touches many facets of the modern web. This article provides an expansive look at how developers can harness these technologies responsibly.
+    </p>
+    <p>
+      One immediate application of AI is in personalized content. By analyzing user behavior and preferences, algorithms can highlight articles, products, or tutorials that are most likely to engage. While this may seem straightforward, it involves responsible data handling practices and clear consent from users to maintain trust.
+    </p>
+    <p>
+      Natural language processing has dramatically improved search interfaces. Instead of rigid keyword matching, semantic understanding allows visitors to phrase their queries naturally and still receive accurate results. Implementing these systems often requires a combination of pre-trained models and domain-specific tuning to maintain both speed and relevance.
+    </p>
+    <p>
+      Another area gaining traction is accessibility automation. Tools now leverage computer vision and machine learning to detect low-contrast text or missing alternative descriptions in images. These insights help developers fix issues early in the design process, creating inclusive experiences for all users.
+    </p>
+    <p>
+      On the backend, AI assists in predictive caching and load balancing. By examining traffic patterns, it can anticipate surges in demand and allocate resources ahead of time. This not only keeps performance stable but also minimizes waste, ensuring that servers are used efficiently.
+    </p>
+    <p>
+      Security benefits as well. Machine learning algorithms analyze logs to detect suspicious patterns that might indicate a breach or attempted attack. By automating the first line of defense, teams can respond faster and reduce the window of vulnerability.
+    </p>
+    <p>
+      Ethical considerations must never be overlooked. Developers should be aware of biases present in training data and provide transparency about how models influence content or decisions. Open communication builds confidence among users and fosters a healthier relationship with technology.
+    </p>
+    <p>
+      Integrating AI into web workflows often begins with small experiments. For instance, developers might embed a chatbot powered by a natural language model to answer frequently asked questions. Gathering feedback from real users helps refine these solutions, turning initial prototypes into robust features.
+    </p>
+    <p>
+      Beyond text and data, AI-driven design tools can suggest color palettes, layouts, or imagery. They enable designers to iterate rapidly, though human supervision remains essential to ensure the final product aligns with brand identity and accessibility standards.
+    </p>
+    <p>
+      Training custom models requires computational resources and curated datasets. Frameworks like TensorFlow and PyTorch simplify experimentation, but they also bring challenges in deployment. Serverless inference platforms are making it easier to scale these models without managing complex infrastructure.
+    </p>
+    <p>
+      Real-time features such as language translation or voice recognition raise the bar for interactive applications. Browsers continue to evolve to support these capabilities, yet developers should always consider fallback strategies for users with limited bandwidth or older hardware.
+    </p>
+    <p>
+      Testing AI components differs from conventional unit tests. Because outputs are probabilistic, successful validation focuses on ranges and behavior rather than exact values. Establishing metrics for accuracy and user satisfaction guides improvement over time.
+    </p>
+    <p>
+      Collaboration between developers and data scientists becomes vital as models grow more complex. Shared terminology, clear versioning of data, and robust documentation prevent misunderstandings. Continuous integration of datasets is as important as code integration when AI drives core features.
+    </p>
+    <p>
+      Looking ahead, AI will continue to shape the landscape of web development. With responsible practices and a willingness to experiment, teams can unlock new ways to delight users and streamline workflows. The key lies in balancing automation with human-centered design.
+    </p>
+    <p>
+      <strong>Tags:</strong> artificial intelligence, web development, machine learning, accessibility, automation
+    </p>
+  </main>
+</Layout>

--- a/src/pages/blog/full-stack-practices.astro
+++ b/src/pages/blog/full-stack-practices.astro
@@ -1,0 +1,63 @@
+---
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Modern Full-Stack Development Practices" description="Insights on robust practices for full-stack developers">
+  <main class="prose lg:prose-lg mx-auto px-4 py-8">
+    <h1>Modern Full-Stack Development Practices</h1>
+    <p>
+      In the constantly evolving landscape of web development, maintaining a flexible and maintainable stack is key. This article dives deep into approaches that have proven effective for projects ranging from small prototypes to large enterprise platforms. It is intended for developers who want to refine their workflow and adopt habits that scale well with project complexity.
+    </p>
+    <p>
+      One cornerstone of a reliable workflow is consistent version control. Teams benefit greatly from structured branch naming conventions and concise commit messages. Integrating code review processes encourages collaboration and ensures that critical fixes are never rushed. Treating version control as more than a backup system transforms it into a historical narrative of the entire project, enabling newcomers to ramp up quickly.
+    </p>
+    <p>
+      Another important aspect is automated testing. By adopting unit tests for core functions and integration tests for crucial pathways, developers gain confidence that new features will not break existing functionality. Continuous integration services run these tests on every push, making the development cycle more predictable and preventing last-minute surprises.
+    </p>
+    <p>
+      Equally relevant is the use of linters and formatters. Tools such as ESLint and Prettier unify the codebase so that style disputes fade away, leaving more room for discussion about architecture and strategy. Automation ensures that the guidelines are applied consistently, and many editors integrate these tools seamlessly.
+    </p>
+    <p>
+      Modular design drives maintainability. Breaking down features into small, reusable components or modules keeps complexity in check. Whether developing a React frontend or a Node.js backend, designing functions with single responsibilities makes them easier to test and update. This approach aligns with the principle of separation of concerns, a fundamental concept in software engineering.
+    </p>
+    <p>
+      Documentation often gets overlooked, yet it directly influences developer experience. A well-documented project lowers the barrier of entry for new contributors and clarifies business logic for stakeholders. Annotated code combined with a thorough README or wiki page fosters transparency and keeps long-term maintenance costs manageable.
+    </p>
+    <p>
+      Efficient full-stack development also hinges on choosing the right tooling. Modern frameworks like Next.js, Astro, and Django integrate seamlessly with TypeScript or Python type hints. These static types catch common errors at compile time and help editors provide reliable autocompletion. While adding types may seem tedious at first, the long-term benefits outweigh the initial effort.
+    </p>
+    <p>
+      Beyond the framework, the deployment pipeline merits attention. Automating build steps, static analysis, and environment configuration reduces the chance of discrepancies between development and production. Many teams rely on containerization with Docker to ensure parity across machines, giving the entire team a consistent environment to work in.
+    </p>
+    <p>
+      Security considerations are indispensable, especially for full-stack systems exposed to the public internet. Implementing thorough input validation, sanitizing database queries, and enabling secure headers prevent common vulnerabilities. Regular dependency audits minimize the risk of outdated libraries introducing security flaws.
+    </p>
+    <p>
+      Performance optimization ties directly into user satisfaction. Profiling tools identify bottlenecks in rendering or database access, guiding targeted improvements. Techniques such as lazy loading, caching, and efficient database indexing can drastically enhance response times, creating a responsive experience on both desktop and mobile devices.
+    </p>
+    <p>
+      Scalability arises once the application gains traction. Consider implementing horizontal scaling strategies early, even when traffic is still modest. Cloud platforms like Kubernetes or serverless architecture provide elasticity, ensuring that the system can grow as the user base expands without requiring complete rewrites.
+    </p>
+    <p>
+      Logging and monitoring provide crucial visibility into production behavior. Setting up centralized logs and metrics early on helps spot anomalies quickly. Tools such as Grafana, Prometheus, or ELK stacks reveal patterns that might otherwise remain hidden, enabling timely responses to performance drops or errors.
+    </p>
+    <p>
+      Another vital practice is to keep dependencies updated. Many frameworks offer automated upgrade tools that handle breaking changes. Regular updates reduce technical debt and keep the project secure. Scheduling routine maintenance windows, even for small projects, ensures that libraries are not allowed to fall too far behind.
+    </p>
+    <p>
+      Collaboration thrives on clear communication. Agile ceremonies, even in lightweight form, encourage teams to share progress and blockages. Stand-ups and retrospectives create a feedback loop that lets developers reflect on what is working and what needs adjustment. The goal is a culture of continuous improvement, not rigid adherence to processes.
+    </p>
+    <p>
+      On the frontend side, adopting design systems speeds up development and enforces visual consistency. Component libraries built around design tokens can adapt to dark modes or localization with minimal effort. Documentation of the design system helps designers and developers stay aligned, improving collaboration across disciplines.
+    </p>
+    <p>
+      When dealing with data flows, consider the benefits of GraphQL or RESTful APIs with versioning strategies. A carefully structured API reduces coupling between frontend and backend. It enables independent development of new features and prevents a single change from cascading through the entire stack.
+    </p>
+    <p>
+      Lastly, never underestimate the value of continuous learning. The ecosystem evolves rapidly, and devoting time to explore new libraries or paradigms pays off in the long run. Attend meetups, participate in code reviews, and experiment with side projects to keep skills sharp and perspectives fresh.
+    </p>
+    <p>
+      <strong>Tags:</strong> full-stack, best practices, automation, testing, DevOps
+    </p>
+  </main>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Blog" description="List of recent posts">
+  <main class="prose lg:prose-lg mx-auto px-4 py-8">
+    <h1>Blog Posts</h1>
+    <ul>
+      <li><a href="/blog/insights">Oriol Dev Insights</a></li>
+      <li><a href="/blog/full-stack-practices">Modern Full-Stack Development Practices</a></li>
+      <li><a href="/blog/ai-driven-web">AI Driven Web Experiences</a></li>
+    </ul>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- add two long blog articles
- add blog index page listing posts
- link blog from navigation data
- include blog link in footer

## Testing
- `npx prettier --check src/pages/blog/full-stack-practices.astro` *(fails: No parser could be inferred)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
