### PR TITLE
Fix lint config and document lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm run preview
 - `npm run optimize:images` - Optimize images
 - `npm run seo:audit` - Run Lighthouse audit
 - `npm run analyze:bundle` - Analyze bundle size
+- `npm run lint` - Check code style with ESLint
 
 ### SSL Certificate Renewal
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,26 +1,2 @@
-import js from "@eslint/js";
-import react from "eslint-plugin-react";
-import reactHooks from "eslint-plugin-react-hooks";
-import jsxA11y from "eslint-plugin-jsx-a11y";
-import astro from "eslint-plugin-astro";
-
-export default [
-  js.configs.recommended,
-  {
-    files: ["**/*.{js,jsx,ts,tsx,astro}"],
-    plugins: {
-      react,
-      "react-hooks": reactHooks,
-      "jsx-a11y": jsxA11y,
-      astro,
-    },
-    languageOptions: {
-      parserOptions: {
-        ecmaVersion: "latest",
-        sourceType: "module",
-        ecmaFeatures: { jsx: true },
-      },
-    },
-    settings: { react: { version: "detect" } },
-  },
-];
+import config from "./.eslintrc.json" assert { type: "json" };
+export default config;


### PR DESCRIPTION
## Summary
- point eslint config to `.eslintrc.json`
- mention `npm run lint` in README

## Testing
- `npx prettier --check eslint.config.js README.md`
- `npm run lint` *(fails: Cannot find module '/workspace/CV_Astro/node_modules/eslint/use-at-eslint')*