### PR TITLE
Replace FA download icon with lucide component

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.4.1",
     "rimraf": "^5.0.5",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "lucide-react": "^0.368.0"
   },
   "devDependencies": {
     "@eslint/js": "^8.57.1",

--- a/src/components/PDFDownload.jsx
+++ b/src/components/PDFDownload.jsx
@@ -4,6 +4,7 @@
  * File: src/components/PDFDownload.jsx
  */
 import React from "react";
+import Icon from "./common/Icon";
 
 const PDFDownload = ({ label = "Download CV", className = "" }) => {
   // Function to handle PDF download
@@ -30,7 +31,7 @@ const PDFDownload = ({ label = "Download CV", className = "" }) => {
       className={`inline-flex items-center px-3 py-1.5 text-sm text-white bg-brand-red rounded-none hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-red focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${className}`}
       aria-label={label}
     >
-      <i className="fas fa-download mr-1.5"></i>
+      <Icon name="download" className="mr-1.5" />
       <span>{label}</span>
     </button>
   );

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import * as Icons from "lucide-react";
+
+interface IconProps {
+  name: string;
+  className?: string;
+  size?: number | string;
+  [key: string]: any;
+}
+
+const toPascal = (str: string) =>
+  str
+    .split(/[-_\s]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+
+const aliasMap: Record<string, string> = {
+  "calendar-alt": "Calendar",
+  "file-alt": "File",
+  "external-link-alt": "ExternalLink",
+  "exclamation-circle": "AlertCircle",
+  "graduation-cap": "GraduationCap",
+  "map-marker-alt": "MapPin",
+};
+
+const Icon: React.FC<IconProps> = ({
+  name,
+  className = "",
+  size = 16,
+  ...props
+}) => {
+  const key = aliasMap[name] || toPascal(name);
+  const LucideIcon = (Icons as any)[key];
+  if (!LucideIcon) return null;
+  return <LucideIcon className={className} size={size} {...props} />;
+};
+
+export default Icon;


### PR DESCRIPTION
## Summary
- add reusable `Icon` component using lucide-react
- update `PDFDownload` to use new icon
- include `lucide-react` dependency

## Testing
- `npx prettier --check src/components/common/Icon.tsx src/components/PDFDownload.jsx package.json`
- `npm run lint` *(fails: Cannot find module '/workspace/CV_Astro/.eslintrc.json')*