### PR TITLE
fix(seo): differentiate /es vs /spain metadata + single H1 on geo pages

### DIFF
--- a/src/components/cv/ProfileHeader.astro
+++ b/src/components/cv/ProfileHeader.astro
@@ -8,9 +8,16 @@ import SvgIcons from "../icons/SvgIcons.astro";
 
 interface Props {
     lang?: string;
+    asH1?: boolean;
 }
 
-const { lang = "en" } = Astro.props;
+const { lang = "en", asH1 = true } = Astro.props;
+
+// Heading levels: this component is the page H1 on the home/language pages, but the geo
+// pages (/spain, /switzerland) own the page H1 (their geo hero) and embed this CV — so
+// there it renders as H2/H3 (asH1={false}) to keep a single H1 per page.
+const NameTag = asH1 ? "h1" : "h2";
+const TitleTag = asH1 ? "h2" : "h3";
 
 // Helper to get translations safely
 const getTranslation = (key: string, fallback: string) => {
@@ -67,12 +74,12 @@ const githubLabel = getTranslation("header.github", "GitHub");
                     sizing); duplicating per-breakpoint produced 2x h1/h2 in
                     the DOM, flagged by SEO crawlers */}
                 <div>
-                    <h1 class="text-2xl leading-tight mb-1 sm:text-4xl md:text-5xl sm:mb-2 font-bold">
+                    <NameTag class="text-2xl leading-tight mb-1 sm:text-4xl md:text-5xl sm:mb-2 font-bold">
                         {headerData.fullName}
-                    </h1>
-                    <h2 class="text-base leading-tight sm:text-xl md:text-2xl text-accessible-brand-red font-semibold">
+                    </NameTag>
+                    <TitleTag class="text-base leading-tight sm:text-xl md:text-2xl text-accessible-brand-red font-semibold">
                         {jobTitle}
-                    </h2>
+                    </TitleTag>
                 </div>
 
                 {/* Mobile: Personal info + Photo side by side */}

--- a/src/pages/spain/index.astro
+++ b/src/pages/spain/index.astro
@@ -135,7 +135,7 @@ const breadcrumbs = [
     </section>
 
     <!-- Standard CV Sections -->
-    <ProfileHeader lang="es" />
+    <ProfileHeader lang="es" asH1={false} />
     <Experience lang="es" />
     <Skills lang="es" />
   </div>

--- a/src/pages/switzerland/index.astro
+++ b/src/pages/switzerland/index.astro
@@ -180,7 +180,7 @@ const description = "Senior Backend Developer seeking opportunities across Switz
     </section>
 
     <!-- Standard CV Sections -->
-    <ProfileHeader lang="en" />
+    <ProfileHeader lang="en" asH1={false} />
     <Experience lang="en" />
     <Skills lang="en" />
   </div>

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -186,12 +186,20 @@ export function detectMarketAndOptimizeSEO(
                     "python entwickler schweiz, backend entwickler schweiz, python entwickler zürich, software ingenieur schweiz, b-bewilligung";
             }
         }
-        // Spanish market detection
-        else if (
-            pathSegments.includes("espana") ||
-            pathSegments.includes("spain") ||
-            language === "es"
-        ) {
+        // Spain geo page — Spain-market specific. Checked BEFORE the language==="es" branch
+        // because /spain renders with lang="es"; otherwise /es and /spain served identical
+        // title + description (duplicate-content flag in crawlers).
+        else if (pathSegments.includes("espana") || pathSegments.includes("spain")) {
+            detectedMarket = "spain";
+            enhancedTitle =
+                "Oriol Macias - Desarrollador Backend en España | Madrid y Barcelona";
+            enhancedDescription =
+                "Desarrollador backend senior en España: Python, Django, C#, protocolos industriales (SNMP/Modbus/BACnet). 8+ años. Disponible en Madrid y Barcelona.";
+            enhancedKeywords =
+                "desarrollador backend madrid, desarrollador backend barcelona, python desarrollador españa, ingeniero software madrid";
+        }
+        // Spanish language home (general / Switzerland-oriented)
+        else if (language === "es") {
             detectedMarket = "spain";
             enhancedTitle =
                 "Oriol Macias - Desarrollador Backend Senior | España y Suiza";


### PR DESCRIPTION
- /es (Spanish-language home) and /spain (Spain geo page) served identical title + meta description because both hit the same detectMarket branch (and /spain renders with lang="es"). Split: /spain now targets the Spain market (Madrid/Barcelona) with a distinct title + description; /es keeps the general España-y-Suiza one. Resolves the duplicate-title + duplicate-description flags. Both ≤160 chars.
- Geo pages (/spain, /switzerland) had two H1s (the geo hero + the embedded CV's "Oriol Macias"). ProfileHeader now takes an asH1 prop (default true); geo pages pass asH1={false}, so the name renders as H2 (subtitle H3) and the geo hero stays the single H1. Google tolerates multiple H1, but one is cleaner for structure + screen readers.

Verified: all 6 pages now 1 H1; /es and /spain distinct; pnpm check + lint green.