### PR TITLE
fix(ui): make light-mode card borders more visible

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -31,7 +31,7 @@ const languageOptions = [
 
 <nav
     id="main-navbar"
-    class="py-4 sticky top-0 z-50 bg-white/50 dark:bg-dark-primary/50 backdrop-blur-xs border-b border-gray-200 dark:border-dark-border"
+    class="py-4 sticky top-0 z-50 bg-white/50 dark:bg-dark-primary/50 backdrop-blur-xs border-b border-light-border dark:border-dark-border"
     role="navigation"
     aria-label="Main Navigation"
     data-lang={lang}
@@ -105,7 +105,7 @@ const languageOptions = [
                 </button>
                 <div
                     id="lang-dropdown"
-                    class="hidden absolute right-0 mt-2 w-36 bg-white dark:bg-dark-surface border border-gray-200 dark:border-dark-border rounded-none shadow-lg z-50 overflow-hidden"
+                    class="hidden absolute right-0 mt-2 w-36 bg-white dark:bg-dark-surface border border-light-border dark:border-dark-border rounded-none shadow-lg z-50 overflow-hidden"
                     role="listbox"
                 >
                     <div class="py-1">
@@ -173,7 +173,7 @@ const languageOptions = [
     <!-- Mobile Navigation Menu -->
     <div
         id="mobile-menu"
-        class="md:hidden hidden absolute left-0 right-0 px-4 pt-2 pb-4 bg-white dark:bg-dark-primary border-b border-gray-200 dark:border-dark-border shadow-lg"
+        class="md:hidden hidden absolute left-0 right-0 px-4 pt-2 pb-4 bg-white dark:bg-dark-primary border-b border-light-border dark:border-dark-border shadow-lg"
         role="menu"
         aria-labelledby="mobile-menu-button"
     >
@@ -190,7 +190,7 @@ const languageOptions = [
             ))}
 
             <!-- Social links (mobile) -->
-            <div class="flex items-center gap-4 py-2 px-3 border-t border-gray-200 dark:border-gray-700 mt-2">
+            <div class="flex items-center gap-4 py-2 px-3 border-t border-light-border dark:border-gray-700 mt-2">
                 <a
                     href="https://github.com/MaciWP"
                     target="_blank"

--- a/src/components/cv/Skills.astro
+++ b/src/components/cv/Skills.astro
@@ -43,11 +43,11 @@ const getIconName = (faClass: string): string => {
   </div>
 
   <!-- Main container -->
-  <div class="bg-white dark:bg-dark-surface p-6 border border-gray-200 dark:border-dark-border rounded-none shadow-xs section-content-animate" style="--anim-delay: 100ms; transition: background-color 100ms ease-out, border-color 100ms ease-out;">
+  <div class="bg-white dark:bg-dark-surface p-6 border border-light-border dark:border-dark-border rounded-none shadow-xs section-content-animate" style="--anim-delay: 100ms; transition: background-color 100ms ease-out, border-color 100ms ease-out;">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
       {categories.map((category) => (
         <div class={`space-y-4 skill-category-animate${category.full ? ' md:col-span-2' : ''}`} style={`--anim-delay: ${category.delay}ms;`}>
-          <div class="border-b border-gray-200 dark:border-gray-700 pb-3 mb-4">
+          <div class="border-b border-light-border dark:border-gray-700 pb-3 mb-4">
             <h3 class="text-lg font-semibold flex items-center gap-2">
               <div class="w-8 h-8 bg-red-100 dark:bg-red-900/20 flex items-center justify-center rounded-none">
                 <SvgIcons name={category.icon} class="w-4 h-4 text-brand-red" />
@@ -57,7 +57,7 @@ const getIconName = (faClass: string): string => {
           </div>
           <div class="flex flex-wrap gap-3 min-h-[44px]">
             {category.items.map((skill) => (
-              <div class="skill-badge bg-white dark:bg-dark-surface border-2 border-gray-200 dark:border-dark-border px-3 py-2 rounded-none inline-flex items-center justify-center text-sm gap-2 cursor-default hover:border-brand-red hover:bg-red-50 dark:hover:bg-red-900/20 hover:shadow-md hover:-translate-y-0.5" style="transition: background-color 100ms ease-out, border-color 100ms ease-out, transform 100ms ease-out, box-shadow 100ms ease-out;">
+              <div class="skill-badge bg-white dark:bg-dark-surface border-2 border-light-border dark:border-dark-border px-3 py-2 rounded-none inline-flex items-center justify-center text-sm gap-2 cursor-default hover:border-brand-red hover:bg-red-50 dark:hover:bg-red-900/20 hover:shadow-md hover:-translate-y-0.5" style="transition: background-color 100ms ease-out, border-color 100ms ease-out, transform 100ms ease-out, box-shadow 100ms ease-out;">
                 <SvgIcons name={getIconName(skill.icon)} class="w-4 h-4 text-brand-red" />
                 <span>{skill.name}</span>
               </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,7 @@ export default {
                 'light-secondary': '#f3f4f6',     // Secondary background light gray
                 'light-surface': '#ffffff',       // Card surface white
                 'light-surface-alt': '#f7f8fa',   // Alternative surface soft gray
-                'light-border': '#e5e7eb',        // Light gray border
+                'light-border': '#d1d5db',        // Light gray border (gray-300, ~1.5:1 on white — was #e5e7eb/gray-200, too faint)
                 'light-text': '#1f2937',          // Main text near-black
                 'light-text-secondary': '#5f6772', // Secondary text medium gray (AA: 5.2:1 on #f3f4f6)
                 'light-card-bg': '#f3f4f6',       // Card background, similar to dates


### PR DESCRIPTION
Light-mode borders were #e5e7eb (gray-200, ~1.2:1 on white) — nearly invisible. Bump the `light-border` token to #d1d5db (gray-300, ~1.5:1) and unify the 7 stray `border-gray-200` usages (Skills, Navbar) onto that token so light borders have a single source of truth.

Dark mode untouched (dark-border #374151 unchanged); rendered DOM structure identical — only border-color changes (verified vs a pre-change build).

astro check 0/0/0 · eslint 0 · npm run check green