### PR TITLE
feat(blog): add blog (Astro content collections, Giscus, first post)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -50,9 +50,15 @@
 # - astro-compress changes script content after hash calculation
 # - Hundreds of inline style="" attributes from animations
 # - External scripts (Cloudflare Web Analytics) need allowlist
+#
+# giscus (blog comments) additions: script-src + connect-src + frame-src allow
+# https://giscus.app (client.js + the comments iframe); img-src allows
+# https://*.githubusercontent.com (GitHub avatars rendered by giscus). These
+# only take effect on the blog post pages that actually embed giscus; no other
+# page loads it. frame-src keeps 'self' so same-origin frames are unaffected.
 # ===========================================================
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'; upgrade-insecure-requests; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com https://static.cloudflareinsights.com; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'; upgrade-insecure-requests; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://giscus.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.githubusercontent.com; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com https://static.cloudflareinsights.com https://giscus.app; frame-src 'self' https://giscus.app; manifest-src 'self'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -1,0 +1,140 @@
+---
+/**
+ * Giscus comments — GitHub Discussions, no backend, free.
+ * @file src/components/Giscus.astro
+ *
+ * Lazy: the giscus client.js is injected only when the container scrolls into
+ * view (it sits at the page bottom, below the fold), so it never touches
+ * LCP/TBT. Theme-aware: a MutationObserver watches the `<html>` class (the
+ * navbar's theme toggle mutates it but emits no event) and posts `setConfig`
+ * to the giscus iframe so comments restyle with the site's dark/light toggle.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * OWNER SETUP (one-time, not code — required before comments appear)
+ *   1. Make the GitHub repo PUBLIC and enable the "Discussions" feature.
+ *   2. Install the giscus app: https://github.com/apps/giscus (grant it the repo).
+ *   3. Go to https://giscus.app, enter the repo, pick a Discussions category
+ *      (e.g. "Announcements"), and copy the generated `data-repo-id` and
+ *      `data-category-id`.
+ *   4. Paste those two values into GISCUS_CONFIG below (replacing the TODO_*
+ *      placeholders) and set `category` to the category name you chose.
+ *
+ * Until repoId AND categoryId are filled in, this component renders NOTHING
+ * visible (just an HTML comment) — no broken widget on a live page.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+// Single source of truth for the giscus configuration.
+const GISCUS_CONFIG = {
+  repo: 'MaciWP/CV_Astro',      // TODO owner: confirm this is the PUBLIC repo with Discussions on
+  repoId: 'TODO_REPO_ID',       // TODO owner: paste data-repo-id from giscus.app
+  category: 'Announcements',    // TODO owner: the Discussions category name chosen on giscus.app
+  categoryId: 'TODO_CATEGORY_ID', // TODO owner: paste data-category-id from giscus.app
+};
+
+const configured =
+  !GISCUS_CONFIG.repoId.startsWith('TODO') &&
+  !GISCUS_CONFIG.categoryId.startsWith('TODO');
+---
+
+{
+  configured ? (
+    <section class="giscus-wrap" aria-label="Comments">
+      <div
+        class="giscus"
+        data-giscus
+        data-repo={GISCUS_CONFIG.repo}
+        data-repo-id={GISCUS_CONFIG.repoId}
+        data-category={GISCUS_CONFIG.category}
+        data-category-id={GISCUS_CONFIG.categoryId}
+      />
+    </section>
+  ) : (
+    <Fragment set:html="<!-- Giscus comments: fill repoId + categoryId in src/components/Giscus.astro to enable (see file header). -->" />
+  )
+}
+
+<style>
+  .giscus-wrap {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--giscus-sep, #d1d5db);
+  }
+  :global(.dark) .giscus-wrap {
+    --giscus-sep: #374151;
+  }
+</style>
+
+<script>
+  // Lazy-init giscus: inject the client only when the container nears the
+  // viewport. No-op when the container is absent (i.e. not configured yet).
+  function initGiscus() {
+    const container = document.querySelector<HTMLElement>('[data-giscus]');
+    if (!container || container.dataset.giscusInit === '1') return;
+    container.dataset.giscusInit = '1';
+
+    const currentTheme = () =>
+      document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+
+    const sendTheme = (theme: string) => {
+      const frame = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+      frame?.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme } } },
+        'https://giscus.app',
+      );
+    };
+
+    let loaded = false;
+    const load = () => {
+      if (loaded) return;
+      loaded = true;
+
+      const s = document.createElement('script');
+      s.src = 'https://giscus.app/client.js';
+      s.setAttribute('data-repo', container.dataset.repo || '');
+      s.setAttribute('data-repo-id', container.dataset.repoId || '');
+      s.setAttribute('data-category', container.dataset.category || '');
+      s.setAttribute('data-category-id', container.dataset.categoryId || '');
+      s.setAttribute('data-mapping', 'pathname');
+      s.setAttribute('data-strict', '0');
+      s.setAttribute('data-reactions-enabled', '1');
+      s.setAttribute('data-emit-metadata', '0');
+      s.setAttribute('data-input-position', 'bottom');
+      s.setAttribute('data-theme', currentTheme());
+      s.setAttribute('data-lang', 'en');
+      s.setAttribute('data-loading', 'lazy');
+      s.crossOrigin = 'anonymous';
+      s.async = true;
+      container.appendChild(s);
+
+      // Keep giscus in sync with the site theme toggle (class mutation only).
+      new MutationObserver(() => sendTheme(currentTheme())).observe(
+        document.documentElement,
+        { attributes: true, attributeFilter: ['class'] },
+      );
+    };
+
+    if ('IntersectionObserver' in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) {
+            io.disconnect();
+            load();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      io.observe(container);
+    } else if (document.readyState === 'complete') {
+      load();
+    } else {
+      window.addEventListener('load', load, { once: true });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initGiscus);
+  } else {
+    initGiscus();
+  }
+</script>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -13,8 +13,16 @@ interface Props {
 
 const { lang = 'en' } = Astro.props;
 
+// Logo links to the current language's home (root), preserving the locale.
+const homeHref = lang === 'en' ? '/' : `/${lang}`;
+
 // Get translated nav items and UI texts at build time
 const translatedNavItems = getNavItems(lang);
+
+// Blog is a REAL page link (not an in-page scroll anchor). It deliberately
+// omits the `nav-link`/`data-section` hooks so the navbar JS leaves it as
+// normal navigation. Highlight it when the current page is within /blog.
+const isBlogSection = Astro.url.pathname.startsWith('/blog');
 const uiTexts = {
     downloadCV: getUITranslation('downloadCV', lang),
     openMenu: getUITranslation('openMenu', lang),
@@ -39,15 +47,15 @@ const languageOptions = [
     <div class="container mx-auto px-4 flex justify-between items-center max-w-5xl">
         <!-- Logo section -->
         <div class="flex items-center gap-4">
-            <button
+            <a
                 id="navbar-logo"
-                class="flex items-center gap-2 cursor-pointer bg-transparent border-none p-0"
-                type="button"
-                aria-label="Oriol Macias — back to top"
+                href={homeHref}
+                class="flex items-center gap-2 cursor-pointer no-underline"
+                aria-label="Oriol Macias — home"
             >
                 <span class="w-12 h-12 flex items-center justify-center bg-brand-red text-white text-lg font-bold" aria-hidden="true">OM</span>
                 <span class="font-medium tracking-tight whitespace-nowrap">Oriol Macias</span>
-            </button>
+            </a>
 
             <!-- Social links (desktop) -->
             <div class="hidden md:flex items-center gap-3">
@@ -86,6 +94,24 @@ const languageOptions = [
                     </a>
                 </li>
             ))}
+            <!-- Blog: real page navigation (no nav-link/data-section hooks) -->
+            <li class="shrink-0">
+                <a
+                    href="/blog"
+                    class:list={[
+                        'relative px-2 py-2 text-sm font-medium transition-colors duration-100 block text-center whitespace-nowrap',
+                        isBlogSection
+                            ? 'text-brand-red'
+                            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200',
+                    ]}
+                    aria-current={isBlogSection ? 'page' : undefined}
+                >
+                    Blog
+                    {isBlogSection && (
+                        <span class="absolute -bottom-1 left-0 right-0 h-0.5 bg-brand-red" aria-hidden="true"></span>
+                    )}
+                </a>
+            </li>
         </ul>
 
         <!-- Controls -->
@@ -188,6 +214,20 @@ const languageOptions = [
                     {item.name}
                 </a>
             ))}
+            <!-- Blog: real page navigation (no mobile-nav-link/data-section hooks) -->
+            <a
+                href="/blog"
+                class:list={[
+                    'text-sm font-medium py-2 px-3',
+                    isBlogSection
+                        ? 'text-brand-red'
+                        : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200',
+                ]}
+                aria-current={isBlogSection ? 'page' : undefined}
+                role="menuitem"
+            >
+                Blog
+            </a>
 
             <!-- Social links (mobile) -->
             <div class="flex items-center gap-4 py-2 px-3 border-t border-light-border dark:border-gray-700 mt-2">
@@ -458,14 +498,21 @@ function initNavbar() {
         }
     }
 
-    // Logo click - scroll to top
-    function handleLogoClick() {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-        updateActiveLink('experience');
-        history.pushState(null, '', window.location.pathname);
-        if (window.announceToScreenReader) {
-            window.announceToScreenReader('Returned to the top of the page');
+    // Logo click: the <a> navigates to the current language's home (root). If we're
+    // already on that home page, just smooth-scroll to top (no reload).
+    const homeHref = lang === 'en' ? '/' : '/' + lang;
+    function handleLogoClick(e) {
+        const path = window.location.pathname.replace(/\/$/, '') || '/';
+        if (path === homeHref) {
+            e.preventDefault();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            updateActiveLink('experience');
+            history.pushState(null, '', window.location.pathname);
+            if (window.announceToScreenReader) {
+                window.announceToScreenReader('Returned to the top of the page');
+            }
         }
+        // Otherwise let the <a href> navigate to the language home normally.
     }
 
     // Event listeners

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,47 @@
+/**
+ * Content Collections config — the blog collection.
+ * @file src/content.config.ts
+ *
+ * Astro 6 Content Layer API: the `glob` loader reads Markdown from
+ * src/content/blog and validates frontmatter against the Zod schema below.
+ * `z` is re-exported by Astro (astro/zod) — NO `zod` dependency is added.
+ * This file lives at src/content.config.ts (the canonical Astro 5/6 location),
+ * NOT the legacy src/content/config.ts.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * HOW TO ADD A POST
+ *   1. Create src/content/blog/<kebab-slug>.md (Markdown only — `.mdx` is NOT
+ *      enabled and adding @astrojs/mdx is out of policy). The filename (minus
+ *      .md) becomes the URL slug: /blog/<kebab-slug>.
+ *   2. Add the frontmatter block (see the schema below). `draft: true` keeps a
+ *      post out of production builds (and the sitemap); it stays visible in
+ *      `pnpm run dev`. Flip to `draft: false` to publish.
+ *   3. Code fences are highlighted by Astro's built-in Shiki (no dependency).
+ *   4. Run `pnpm run build` — the new page and its sitemap entry are automatic.
+ *
+ * LANGUAGE POLICY
+ *   Blog posts are ENGLISH-ONLY by design. The 4-language CV i18n
+ *   (src/data/locales/*, the near-duplicate index pages) is deliberately NOT
+ *   extended to the blog: per-post translation into en/es/fr/de is
+ *   unsustainable and the technical audience reads English. Do not wire blog
+ *   content into `check:translations`.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
+
+const blog = defineCollection({
+  loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/building-a-claude-code-orchestrator.md
+++ b/src/content/blog/building-a-claude-code-orchestrator.md
@@ -1,0 +1,76 @@
+---
+title: "Building an orchestration layer for Claude Code: an honest retrospective"
+description: "I wanted 5–10 agents working in parallel, dividing the work and talking to each other. It launched one, cost far more tokens, ran slower, and the skills wouldn't even load. Here is what went wrong, why, and the iterative flow I landed on instead."
+pubDate: 2026-06-18
+tags: ["claude-code", "ai-agents", "orchestration", "developer-tools", "retrospective"]
+draft: false
+---
+
+<!--
+  OWNER NOTE (not rendered): drafted from your own account, the plan/retro
+  documents in the poneglyph repo, and our development conversations. Read it end
+  to end — it's your story and your voice; correct anything that rings false.
+  No metric here is invented:
+    - "112k tokens / 8m15s / zero parallelism" is from plan 007's retro (one
+      delegated skill run).
+    - "~278k tokens for zero verdicts" is from plan 017's retro (a late review
+      panel that hit the session limit).
+  Both are real and yours — keep or cut them as you prefer. Nothing is public
+  until you `git push`.
+-->
+
+For a while, the centerpiece of my work with [Claude Code](https://www.anthropic.com/claude-code) was an orchestration layer I was building on top of it. The idea felt like the obvious next level: instead of one assistant working through a task, have it break the work into atomic pieces and run **five or ten agents in parallel** — each with its own focused context, each owning a well-defined slice, talking to each other to coordinate. More throughput, less context bloat, faster results.
+
+It did the opposite of all three. It cost more, it ran slower, and the quality went down. This is the honest write-up.
+
+## The dream
+
+The shape I was after was a team, not a tool. A "lead" would plan the work and split it; independent pieces would run as separate agents at the same time; each agent would get an isolated context so the main conversation stayed clean; and they'd communicate to hand off the parts that depend on each other. On paper, that's how you turn a single assistant into something that scales.
+
+Claude Code gives you the building blocks — **subagents** for delegation, **skills** for reusable instructions, **hooks** for event-driven scripts. I wired them together into logic that decided when to split work and which skill each step should use.
+
+## What actually happened
+
+The reality, in my own words at the time:
+
+> I thought the next level was having 5 or 10 agents in parallel to go much faster, but it has a lot of drawbacks. There's no communication between them. Often the main session wanted to do the work and I had to force myself to change how I worked — and when I finally managed it, only one agent got invoked, so it spent more tokens, many more, and didn't improve anything: slower, more expensive, lower quality. In the end I removed them all.
+
+Concretely, four things broke:
+
+- **It serialized to a single agent.** Where I expected a fan-out, the system kept launching *one* agent and waiting for it. No concurrency, no speed-up — just an extra layer between me and the work.
+- **Token cost multiplied.** Every delegation re-sends context to the agent and summarizes the result back. One delegated run of a single skill cost ~112k tokens and over eight minutes for *zero* parallelism, much of it re-reading files the main session already had. Another time, a review panel I launched late burned ~278k tokens and returned nothing, because the agents hit the session limit before producing a verdict.
+- **The agents couldn't talk to each other.** The one thing my "team" idea depended on — coordination — wasn't really there.
+- **Skills wouldn't activate.** Agents ignored the skill that should have governed a step. The irony peaked when I realized the orchestration skill *meant to run the whole thing* often never loaded at all — the behavior only happened because I'd also written it into the always-loaded config.
+
+## Why it failed
+
+The interesting part is the diagnosis, because the symptoms have *different* root causes. Lumping them into "agents don't work" hides that.
+
+**The summary bottleneck.** When an agent writes code and hands back a summary, detail is lost in the summary. The lead then has to review code it never "saw born." For write-heavy work, quality drops *by design* — not because of a bad invocation.
+
+**The economics of context.** Each agent re-pays the cost of orienting itself. A fan-out of five pays five times for the context the main session already had amortized. Isolation helps a *reader*; it taxes a *writer*.
+
+**Skills are non-deterministic on purpose.** Claude Code doesn't pick a skill from an index — the model semantically matches your request against each skill's description, and it tends to *under*-trigger. No mechanism forces activation; a hook can only nudge. And a skill loaded in the main session **does not carry over to a spawned subagent** — so my delegated agents started without the very instructions they needed. My fix at the time (rules telling agents to read the skill files manually) was the lowest-leverage option available. The highest-leverage one, which I found later, is almost embarrassing: write more directive descriptions ("Use when…", with concrete triggers). That single change moves activation more than any hook.
+
+**And the reframe that reorganized everything:** even if ten agents *did* generate code in parallel, the bottleneck of the system is *me*. Quality-first means I review and decide serially. Parallelizing the generation doesn't speed the system up — it just moves the queue to me. I was optimizing the part that wasn't the constraint.
+
+## The part I couldn't do: measure it
+
+I want to be honest about a gap. I concluded "it cost more" because it was *obvious*, not because I measured it cleanly. I waived measurement more than once. And that's the genuinely hard problem: these systems are non-deterministic, so the same task delegated twice doesn't cost or behave the same way, and a clean before/after is hard to pin down. I'll need that instrumentation anyway — deciding by doctrine instead of by data only works until the doctrine is wrong.
+
+## What I changed
+
+I stopped trying to make agents do the writing. The system now runs on two rules:
+
+1. **Inline-first.** All build and write work happens in the main session, with direct edits. One agent is never worth it. Agents are reserved for genuinely parallel, *read-only* work, and only when there are enough independent units to justify it.
+2. **A structured, iterative flow instead of a swarm.** Work moves through explicit phases — scope, plan, design checks, build, review, retrospective — each with a human gate. Slower per step on paper, but it converges, it's debuggable, and it doesn't burn tokens re-explaining itself. (The trap here is ceremony: a many-step flow can over-process a small task. The fix is adaptive triage — match the weight of the process to the size of the work.)
+
+## What actually worked
+
+Not everything about agents failed — I'd pointed them at the wrong half of the problem. The half that works *today* is the read-only, verification side. Fanning out independent reviewers and having one agent try to *refute* another's finding caught real mistakes every single time I ran it: wrong figures, stale numbers, a miscited claim. That kind of adversarial verification isn't ceremony — it's where the rigor actually lives. An independent reviewer with fresh context changed real outcomes instead of rubber-stamping them. Parallelism there is close to free, and it makes the output better.
+
+## Where I think this goes
+
+I haven't given up on the team idea — agents that divide the work and communicate is still the version of the future I'd bet on. But I'll be honest about the state of it: that's the *least* mature part right now. Cross-agent communication is minimal, agents can't yet take on specialized roles or delegate further, and the whole mode is experimental and expensive. So my plan isn't to force it. It's to keep the writing inline, let agents do the reading and the checking where they already shine, instrument the cost so I can *see* when delegation pays — and pick the team model back up when the tooling, and my measurements, are ready for it.
+
+<!-- TODO: optional — once the poneglyph repo is public, link it here as "the system this post is about." And if you want, name the iterative flow explicitly. -->

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,0 +1,200 @@
+---
+/**
+ * Blog post layout — wraps Layout.astro with reading-optimized typography,
+ * the BlogPosting JSON-LD (injected into <head> via Layout's `head` slot),
+ * a "← Back to blog" link, and the lazy, theme-aware Giscus comments.
+ * @file src/layouts/BlogPost.astro
+ */
+import Layout from './Layout.astro';
+import Giscus from '../components/Giscus.astro';
+
+export interface Props {
+  title: string;
+  description: string;
+  pubDate: Date;
+  updatedDate?: Date;
+  tags?: string[];
+  /** Collection entry id — becomes the /blog/<slug> URL segment. */
+  slug: string;
+}
+
+const { title, description, pubDate, updatedDate, tags = [], slug } = Astro.props;
+
+const SITE = 'https://oriolmacias.dev';
+const canonical = `${SITE}/blog/${slug}`;
+
+// Deterministic at build time (formats the fixed frontmatter date, not "now").
+const fmt = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+const displayDate = fmt.format(pubDate);
+const displayUpdated = updatedDate ? fmt.format(updatedDate) : null;
+
+// BlogPosting structured data (author "Oriol Macias", per the SEO brief).
+const blogPostingSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: title,
+  description,
+  datePublished: pubDate.toISOString(),
+  dateModified: (updatedDate ?? pubDate).toISOString(),
+  author: { '@type': 'Person', name: 'Oriol Macias', url: SITE },
+  publisher: { '@type': 'Person', name: 'Oriol Macias', url: SITE },
+  mainEntityOfPage: { '@type': 'WebPage', '@id': canonical },
+  image: `${SITE}/images/oriol_macias-1280.jpg`,
+  url: canonical,
+  inLanguage: 'en',
+};
+---
+
+<Layout
+  title={`${title} — Oriol Macias`}
+  description={description}
+  lang="en"
+  canonicalUrl={canonical}
+>
+  <Fragment
+    slot="head"
+    set:html={`<script type="application/ld+json">${JSON.stringify(blogPostingSchema)}</script>`}
+  />
+
+  <article class="blog-post mx-auto">
+    <a
+      href="/blog"
+      class="inline-flex items-center gap-1 text-sm font-medium text-accessible-brand-red hover:underline mb-8"
+    >
+      <span aria-hidden="true">←</span> Back to blog
+    </a>
+
+    <header class="mb-8">
+      <h1 class="text-3xl sm:text-4xl font-bold tracking-tight mb-3">{title}</h1>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-light-text-secondary dark:text-dark-text-secondary">
+        <time datetime={pubDate.toISOString()}>{displayDate}</time>
+        {displayUpdated && <span>· Updated {displayUpdated}</span>}
+        {
+          tags.length > 0 && (
+            <ul class="flex flex-wrap gap-2" aria-label="Tags">
+              {tags.map((tag) => (
+                <li class="px-2 py-1 text-xs font-medium bg-brand-red/10 text-brand-red dark:bg-brand-red/20 dark:text-red-300 border border-brand-red/20 rounded-none">
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          )
+        }
+      </div>
+    </header>
+
+    <div class="post-prose">
+      <slot />
+    </div>
+
+    <Giscus />
+  </article>
+</Layout>
+
+<style>
+  /* Reading column: ~65ch, comfortable line-height, site fonts, dark/light. */
+  .blog-post {
+    max-width: 65ch;
+  }
+
+  .post-prose {
+    line-height: 1.65;
+    color: #1f2937; /* light-text */
+    font-size: 1.0625rem;
+  }
+  :global(.dark) .post-prose {
+    color: #f9fafb; /* dark-text */
+  }
+
+  /* Headings — Outfit via the global h1–h6 rule; spacing tuned for prose. */
+  .post-prose :global(h2) {
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin: 2.5rem 0 0.75rem;
+    line-height: 1.25;
+  }
+  .post-prose :global(h3) {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 1.75rem 0 0.5rem;
+    line-height: 1.3;
+  }
+  .post-prose :global(p) {
+    margin: 0 0 1.25rem;
+  }
+  .post-prose :global(ul),
+  .post-prose :global(ol) {
+    margin: 0 0 1.25rem;
+    padding-left: 1.5rem;
+  }
+  .post-prose :global(ul) {
+    list-style: disc;
+  }
+  .post-prose :global(ol) {
+    list-style: decimal;
+  }
+  .post-prose :global(li) {
+    margin-bottom: 0.4rem;
+  }
+  .post-prose :global(li::marker) {
+    color: #d83333; /* brand-red bullets */
+  }
+  .post-prose :global(a) {
+    color: #991b1b; /* accessible red, light */
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  :global(.dark) .post-prose :global(a) {
+    color: #fca5a5; /* accessible red, dark */
+  }
+  /* Inline code */
+  .post-prose :global(:not(pre) > code) {
+    background: #f3f4f6;
+    padding: 0.15em 0.4em;
+    font-size: 0.9em;
+    border-radius: 0; /* sharp corners */
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  :global(.dark) .post-prose :global(:not(pre) > code) {
+    background: #1e2433;
+  }
+  /* Shiki code blocks (.astro-code carries an inline background from the theme) */
+  .post-prose :global(pre) {
+    padding: 1rem 1.25rem;
+    margin: 0 0 1.5rem;
+    overflow-x: auto;
+    border: 1px solid #374151;
+    border-radius: 0; /* sharp corners */
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+  .post-prose :global(blockquote) {
+    border-left: 3px solid #d83333;
+    padding-left: 1rem;
+    margin: 0 0 1.25rem;
+    color: #5f6772;
+    font-style: italic;
+  }
+  :global(.dark) .post-prose :global(blockquote) {
+    color: #9ca3af;
+  }
+  .post-prose :global(hr) {
+    border: 0;
+    border-top: 1px solid #d1d5db;
+    margin: 2.5rem 0;
+  }
+  :global(.dark) .post-prose :global(hr) {
+    border-top-color: #374151;
+  }
+  .post-prose :global(img) {
+    max-width: 100%;
+    height: auto;
+  }
+  .post-prose :global(strong) {
+    font-weight: 600;
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -290,6 +290,9 @@ const isMultilingualPage =
       set:html={`<script type="application/ld+json">${JSON.stringify(websiteSchema, null, 2)}</script>`}
     />
 
+    <!-- Page-specific <head> extras (e.g. BlogPosting JSON-LD from BlogPost layout) -->
+    <slot name="head" />
+
     <!-- Print Styles -->
     <style is:inline>
       @media print{nav,footer,.no-print{display:none!important}body{background:#fff!important;color:#000!important}}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Blog post page — renders a Markdown post through the BlogPost layout.
+ * Drafts are excluded from production builds (so they never reach the
+ * sitemap); they remain available in `pnpm run dev`.
+ * @file src/pages/blog/[...slug].astro
+ */
+import { getCollection, render } from 'astro:content';
+import BlogPost from '../../layouts/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts
+    .filter((post) => (import.meta.env.PROD ? !post.data.draft : true))
+    .map((post) => ({
+      params: { slug: post.id },
+      props: { post },
+    }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogPost
+  title={post.data.title}
+  description={post.data.description}
+  pubDate={post.data.pubDate}
+  updatedDate={post.data.updatedDate}
+  tags={post.data.tags}
+  slug={post.id}
+>
+  <Content />
+</BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,83 @@
+---
+/**
+ * Blog index — lists posts (title, date, description, tags), newest first.
+ * Drafts are hidden in production builds (visible in `pnpm run dev`).
+ * @file src/pages/blog/index.astro
+ */
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog'))
+  .filter((post) => (import.meta.env.PROD ? !post.data.draft : true))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+const fmt = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+const SITE = 'https://oriolmacias.dev';
+const pageTitle = 'Blog — Oriol Macias';
+const pageDescription =
+  'English-only notes on backend development, industrial protocol integration (SNMP/Modbus/BACnet), data center infrastructure, and developer tooling — by Oriol Macias.';
+---
+
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  lang="en"
+  canonicalUrl={`${SITE}/blog`}
+>
+  <section class="mx-auto max-w-3xl">
+    <header class="mb-10">
+      <h1 class="text-3xl sm:text-4xl font-bold tracking-tight mb-2">Blog</h1>
+      <p class="text-light-text-secondary dark:text-dark-text-secondary">
+        Notes on backend engineering, industrial protocols, and developer
+        tooling. Written in English.
+      </p>
+    </header>
+
+    {
+      posts.length === 0 ? (
+        <p class="text-light-text-secondary dark:text-dark-text-secondary">
+          No posts yet — check back soon.
+        </p>
+      ) : (
+        <ul class="space-y-8">
+          {posts.map((post) => (
+            <li>
+              <article class="group">
+                <a href={`/blog/${post.id}`} class="block no-underline">
+                  <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+                    <h2 class="text-xl font-bold tracking-tight transition-colors duration-150 group-hover:text-brand-red">
+                      {post.data.title}
+                    </h2>
+                    <time
+                      datetime={post.data.pubDate.toISOString()}
+                      class="shrink-0 text-sm text-light-text-secondary dark:text-dark-text-secondary"
+                    >
+                      {fmt.format(post.data.pubDate)}
+                    </time>
+                  </div>
+                  <p class="mt-1 text-light-text-secondary dark:text-dark-text-secondary">
+                    {post.data.description}
+                  </p>
+                </a>
+                {post.data.tags.length > 0 && (
+                  <ul class="mt-2 flex flex-wrap gap-2" aria-label="Tags">
+                    {post.data.tags.map((tag) => (
+                      <li class="px-2 py-1 text-xs font-medium bg-brand-red/10 text-brand-red dark:bg-brand-red/20 dark:text-red-300 border border-brand-red/20 rounded-none">
+                        {tag}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </section>
+</Layout>


### PR DESCRIPTION
Minimalist blog integrated into the existing design system, with NO new dependencies and no UI framework (Zod via astro/zod, glob loader via astro/loaders, Shiki for code highlighting).

- src/content.config.ts: blog collection + typed Zod schema (title, description, pubDate, updatedDate?, tags[], draft)
- src/pages/blog/{index,[...slug]}.astro: list + post pages. Drafts hidden in production; /blog and posts are indexable and enter the sitemap; /cv stays excluded (sitemap i18n adds no bogus es/fr/de alternates, verified)
- src/layouts/BlogPost.astro: reading-optimized prose (65ch, line-height 1.65, dark/light), "Back to blog" link, BlogPosting JSON-LD injected via a new named head slot added to Layout.astro
- src/components/Giscus.astro: lazy (IntersectionObserver, below the fold) and theme-aware (MutationObserver on the html class, since the theme toggle emits no event). One config constant with TODO repo/category IDs; renders nothing until configured, so no broken widget on a live page
- public/_headers: CSP allows giscus.app (script-src/connect-src/frame-src) and GitHub avatars (img-src) without weakening the rest
- Navbar: real "Blog" page link (no nav-link/data-section scroll hooks); the logo becomes a real anchor home link so it navigates home from sub-pages

First post (building-a-claude-code-orchestrator) is a real retrospective on building an orchestration layer for Claude Code; owner to review the prose and the two cited figures before it goes public on push.

Verified: pnpm build + check + lint green; CLS-safe (no opacity-fade reveals); no React reintroduced; no dependency added.